### PR TITLE
feat: Add item and power components

### DIFF
--- a/src/lib/components/common/Popover.svelte
+++ b/src/lib/components/common/Popover.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fly } from "svelte/transition";
+  import { fly } from "svelte/transition";
 
   const { children, content } = $props()
 

--- a/src/lib/components/common/Popover.svelte
+++ b/src/lib/components/common/Popover.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { fly } from "svelte/transition";
+
+  const { children, content } = $props()
+
+  let active = $state(false)
+</script>
+
+<div class="popover">
+  <button
+    class="toggle"
+    onmouseenter={() => active = true}
+    onmouseleave={() => active = false}
+    onclick={() => active = !active}>
+    {@render children()}
+  </button>
+
+  {#if active}
+    <div class="content" transition:fly={{ y: 10, duration: 50 }}>
+      {@render content()}
+    </div>
+  {/if}
+</div>
+
+<style lang="scss">
+  .popover {
+    display: inline-block;
+    position: relative;
+  }
+
+  .toggle {
+    appearance: none;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+  }
+
+  .content {
+    z-index: 10;
+    position: absolute;
+    bottom: -1rem;
+    left: 50%;
+    transform: translateX(-50%) translateY(100%);
+    background: $color-bg-dark;
+    border-radius: $border-radius;
+    border-top: 2px solid $color-text-alt;
+    border-bottom: 2px solid $color-text-alt;
+  }
+</style>

--- a/src/lib/components/content/Item.svelte
+++ b/src/lib/components/content/Item.svelte
@@ -1,0 +1,51 @@
+<script>
+  import Popover from "../common/Popover.svelte";
+  import SharedDetail from "./SharedDetail.svelte";
+
+  const { item } = $props();
+
+  const { name, description, icon, rarity, cost } = $derived(item);
+</script>
+
+<Popover>
+  <div class="item {rarity}">
+    <img src={icon} alt={name} />
+  </div>
+
+  {#snippet content()}
+    <SharedDetail {name} {description} {cost} />
+  {/snippet}
+</Popover>
+
+<style lang="scss">
+  @use "sass:color";
+
+  .item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    width: $item-size;
+    height: $item-size;
+    overflow: hidden;
+    padding: 0.25rem;
+    border: 2px solid var(--color-rarity);
+    box-shadow: inset 0 0 0 1px $color-bg-base;
+    background: var(--color-rarity);
+
+    @each $rarity, $color in $color-rarities {
+      &.#{$rarity} {
+        --color-rarity: #{$color};
+
+        &:hover {
+          --color-rarity: #{color.adjust($color, $lightness: 10%)};
+        }
+      }
+    }
+
+    img {
+      width: calc(100% - 0.25rem);
+      height: auto;
+    }
+  }
+</style>

--- a/src/lib/components/content/Power.svelte
+++ b/src/lib/components/content/Power.svelte
@@ -1,0 +1,42 @@
+<script>
+  import Popover from "../common/Popover.svelte";
+  import SharedDetail from "./SharedDetail.svelte";
+
+  const { power } = $props();
+
+  const { name, description, icon } = $derived(power);
+</script>
+
+<Popover>
+  <div class="power">
+    <img src={icon} alt={name} />
+  </div>
+
+  {#snippet content()}
+    <SharedDetail {name} {description} />
+  {/snippet}
+</Popover>
+
+<style lang="scss">
+  @use "sass:color";
+
+  .power {
+    border-radius: $border-radius-small;
+    width: $item-size;
+    height: $item-size;
+    overflow: hidden;
+    border: 2px solid $primary;
+    background: $primary;
+
+    &:hover {
+      border-color: color.adjust($primary, $lightness: 10%);
+    }
+
+    img {
+      width: 100%;
+      height: auto;
+      border-radius: $border-radius-small;
+      border: 1px solid $color-bg-base;
+    }
+  }
+</style>

--- a/src/lib/components/content/SharedDetail.svelte
+++ b/src/lib/components/content/SharedDetail.svelte
@@ -14,7 +14,7 @@
 
   <div class="cost">
     {#if cost}
-      ${cost}
+      ${cost.toLocaleString()}
     {:else}
       Free
     {/if}

--- a/src/lib/components/content/SharedDetail.svelte
+++ b/src/lib/components/content/SharedDetail.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  interface Props {
+    name: string,
+    description: string,
+    cost?: number
+  }
+
+  const { name, description, cost = 0 }: Props = $props();
+</script>
+
+<div class="detail">
+  <strong class="name">{name}</strong>
+  <p class="description">{description}</p>
+
+  <div class="cost">
+    {#if cost}
+      ${cost}
+    {:else}
+      Free
+    {/if}
+  </div>
+</div>
+
+<style lang="scss">
+  .detail {
+    width: 23rem;
+    padding: 1.5rem;
+  }
+
+  .name {
+    display: block;
+    margin-bottom: 1rem;
+    color: $color-text-titles;
+    font-size: 1.2em;
+    line-height: 1.1;
+    font-weight: bold;
+    font-family: $font-stack-brand;
+  }
+
+  .description {
+    margin: 0;
+    padding: 0.5rem 0;
+    border-top: 1px solid rgba($color-text-alt, 0.5);
+    border-bottom: 1px solid rgba($color-text-alt, 0.5);
+    color: $color-text-alt;
+  }
+
+  .cost {
+    margin-top: 1rem;
+    color: $white;
+    font-weight: bold;
+    font-family: $font-stack-brand;
+  }
+</style>

--- a/src/lib/scss/_variables.scss
+++ b/src/lib/scss/_variables.scss
@@ -1,3 +1,5 @@
+@use "$lib/scss/_functions.scss" as *;
+
 $primary: #ee6a1d;
 $secondary: #127da1;
 
@@ -9,6 +11,12 @@ $color-text-base: $secondary;
 $color-text-alt: #6f8aad;
 $color-text-titles: $white;
 $color-border: rgba(#7ab1c3, 0.2);
+
+$color-rarities: (
+  common: #13a530,
+  rare: #207cbd,
+  epic: #8426d2
+);
 
 $font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 $font-stack-brand: "Gilroy", "Impact", sans-serif;
@@ -27,6 +35,7 @@ $breakpoints: (
 $gutter: 1.5rem;
 $vertical-offset-large: clamp($gutter, 10vw, 7.5rem);
 $navigation-height: 5rem;
+$item-size: #{px-to-rem(40)};
 
 $border-radius: 1rem;
 $border-radius-small: $border-radius * 0.5;

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -2,6 +2,7 @@
   import Power from "$lib/components/content/Power.svelte";
   import Item from "$lib/components/content/Item.svelte";
 
+  // Placeholder stuff
   const items = [{
     id: 1,
     name: "Some item",

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -1,11 +1,62 @@
+<script>
+  import Power from "$lib/components/content/Power.svelte";
+  import Item from "$lib/components/content/Item.svelte";
+
+  const items = [{
+    id: 1,
+    name: "Some item",
+    description: "I am some description of an item that will appear in the popover",
+    icon: "https://picsum.photos/seed/a/40",
+    rarity: "common",
+    cost: 4000
+  }, {
+    id: 2,
+    name: "Some item",
+    description: "I am some description of an item that will appear in the popover",
+    icon: "https://picsum.photos/seed/b/40",
+    rarity: "rare",
+    cost: 2000
+  }, {
+    id: 3,
+    name: "Some item",
+    description: "I am some description of an item that will appear in the popover",
+    icon: "https://picsum.photos/seed/c/40",
+    rarity: "epic",
+    cost: 4000
+  }]
+
+  const powers = [{
+    id: 1,
+    name: "Some power",
+    description: "I am some description of a power that will appear in the popover",
+    icon: "https://picsum.photos/40"
+  }]
+</script>
+
 <h1>Welcome to SvelteKit</h1>
 <h2>Smaller title</h2>
 <h3>Smallest title</h3>
 
 <div class="block">
   <p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+
+  <div class="list">
+    {#each items as item (item.id)}
+      <Item {item} />
+    {/each}
+  </div>
+
+  <div class="list">
+    {#each powers as power (power.id)}
+      <Power {power} />
+    {/each}
+  </div>
 </div>
 
 <style lang="scss">
-
+  .list {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1rem;
+  }
 </style>


### PR DESCRIPTION
## Description

This merges into #5 and should be rebased after merging that PR first.

This adds the components for hoverable items and powers. Both are separate components that are fairly similar is shape, but just different enough to warrant different components. They share two componts;
- Popover, which is a hover tooltip. This does not yet contain any logic for better positioning when the tooltip falls offscreen (like on mobile).
- SharedDetail, which is the description that appears in the Popover. This is made to look as close to the game as possible, but I didn't add quite everything yet, icons are missing.

## Screenshots

This uses placeholder images, which do look like crap, but please look past that!
![image](https://github.com/user-attachments/assets/afd7dd18-66fc-4f03-96de-59759876af4e)

### Popover
![image](https://github.com/user-attachments/assets/5bb3cf98-e309-41e6-b65c-78c337f44d3e)
![image](https://github.com/user-attachments/assets/e8b3b127-aac4-4c00-a742-ae67824e1b67)

![items-powers-popover](https://github.com/user-attachments/assets/4f8310bd-54e9-4179-b74b-3dfa478494bd)

