### PR TITLE
feat: Builds list

### DIFF
--- a/src/lib/components/common/Popover.svelte
+++ b/src/lib/components/common/Popover.svelte
@@ -24,11 +24,11 @@
 
 <style lang="scss">
   .popover {
-    display: inline-block;
     position: relative;
   }
 
   .toggle {
+    display: block;
     appearance: none;
     margin: 0;
     padding: 0;

--- a/src/lib/components/content/Build.svelte
+++ b/src/lib/components/content/Build.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	import { goto } from "$app/navigation";
+	import { heroes } from "$lib/constants/heroes";
+	import Hero from "./Hero.svelte";
+	import Item from "./Item.svelte";
+	import Power from "./Power.svelte";
+
+  const power = (id: number) => ({
+    id,
+    name: "Some power",
+    description: "I am some description of a power that will appear in the popover",
+    icon: `https://picsum.photos/seed/${id}/40`
+  })
+
+  const item = (id: number) => ({
+    id,
+    name: "Some power",
+    description: "I am some description of a power that will appear in the popover",
+    icon: `https://picsum.photos/seed/${id}/40`,
+    rarity: "rare",
+    cost: 2000 * id
+  })
+
+  const href = '/build/test'
+
+  function onclick(event: MouseEvent): void {
+    const target = event.target as HTMLElement
+
+    if (target.nodeName === 'A') return
+    if (target.closest('a')) return
+
+    goto(href)
+  }
+</script>
+
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- A proper link can be found right in the div. It doesn't impede a11y. -->
+<div class="build" {onclick}>
+  <Hero hero={heroes[0]} />
+
+  <div class="meta">
+    <a {href} class="name">Some build name</a>
+
+    <div class="author">
+      By <a href="/user/username">user</a>
+    </div>
+  </div>
+
+  <div class="items">
+    {#each { length: 4 }, i}
+      <Power power={power(i + 1)} />
+    {/each}
+
+    {#each { length: 6 }, i}
+      <Item item={item(i + 10)} />
+    {/each}
+  </div>
+</div>
+
+<style lang="scss">
+  .build {
+    $transition-duration: 25ms;
+    --outline-size: 0.5rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    border-radius: $border-radius-small;
+    box-shadow: 0 0 0 $color-bg-light;
+    transition: box-shadow $transition-duration, background-color $transition-duration $transition-duration;
+    cursor: pointer;
+
+    @include breakpoint(tablet) {
+      flex-wrap: nowrap;
+    }
+
+    &:hover,
+    &:active {
+      background: $color-bg-light;
+      box-shadow: 0 0 0 var(--outline-size) $color-bg-light;
+      transition: box-shadow $transition-duration;
+
+      @include breakpoint(tablet) {
+        --outline-size: 1rem;
+      }
+    }
+  }
+
+  .meta {
+    line-height: 1;
+  }
+
+  .name {
+    display: block;
+    margin-bottom: 0.25rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: $font-stack-brand;
+    font-weight: bold;
+    color: $white;
+    text-decoration: none;
+    white-space: nowrap;
+
+    &:hover {
+      box-shadow: 0 2px 0 $white;
+    }
+  }
+
+  .author {
+    font-size: $font-size-small;
+    color: $color-text-alt;
+
+    a {
+      color: $color-text-alt;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+        color: $white;
+      }
+    }
+  }
+
+  .items {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+    min-width: 0;
+
+    @include breakpoint(tablet) {
+      justify-content: flex-end;
+    }
+  }
+</style>

--- a/src/lib/components/content/BuildsList.svelte
+++ b/src/lib/components/content/BuildsList.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import Build from "./Build.svelte";
+
+  interface Props {
+    header: string
+  }
+
+  const { header }: Props = $props()
+</script>
+
+<h1>{header}</h1>
+
+<div class="block list">
+  <Build />
+  <Build />
+  <Build />
+</div>
+
+<style lang="scss">
+  h1 {
+    margin: $vertical-offset-large 0 1rem;
+  }
+
+  .list {
+    display: grid;
+    gap: 2rem;
+  }
+</style>

--- a/src/lib/components/content/BuildsList.svelte
+++ b/src/lib/components/content/BuildsList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Build from "./Build.svelte";
+  import Build from "./Build.svelte";
 
   interface Props {
     header: string

--- a/src/lib/scss/_variables.scss
+++ b/src/lib/scss/_variables.scss
@@ -7,6 +7,7 @@ $white: #fff;
 $black: #000;
 $color-bg-base: #0e2038;
 $color-bg-dark: #091628;
+$color-bg-light: #163853;
 $color-bg-hero: #c8ddf8;
 $color-text-base: $secondary;
 $color-text-alt: #6f8aad;
@@ -41,3 +42,6 @@ $item-size: #{px-to-rem(40)};
 $border-radius: 1rem;
 $border-radius-small: $border-radius * 0.5;
 $border-radius-large: $border-radius * 2;
+
+$font-size-small: 16px;
+$font-size-base: 18px;

--- a/src/lib/scss/global.scss
+++ b/src/lib/scss/global.scss
@@ -16,11 +16,11 @@ body {
   overflow-x: hidden;
   color: $color-text-base;
   font-family: $font-stack;
-  font-size: 16px;
+  font-size: $font-size-small;
   line-height: 1.5;
 
   @include breakpoint(tablet) {
-    font-size: 18px;
+    font-size: $font-size-base;
   }
 
   &::before {

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -2,7 +2,7 @@
   import Heroes from "$lib/components/content/Heroes.svelte";
   import Power from "$lib/components/content/Power.svelte";
   import Item from "$lib/components/content/Item.svelte";
-	import BuildsList from "$lib/components/content/BuildsList.svelte";
+  import BuildsList from "$lib/components/content/BuildsList.svelte";
 
   // Placeholder stuff
   const items = [{

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -2,6 +2,7 @@
   import Heroes from "$lib/components/content/Heroes.svelte";
   import Power from "$lib/components/content/Power.svelte";
   import Item from "$lib/components/content/Item.svelte";
+	import BuildsList from "$lib/components/content/BuildsList.svelte";
 
   // Placeholder stuff
   const items = [{
@@ -37,11 +38,9 @@
 
 <Heroes />
 
-<h1 class="vertical-offset-large">Welcome to SvelteKit</h1>
-<h2>Smaller title</h2>
-<h3>Smallest title</h3>
+<BuildsList header="Latest Builds" />
 
-<div class="block">
+<div class="block vertical-offset-large">
   <p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
 
   <div class="list">


### PR DESCRIPTION
## Description

This adds the builds list with individual build items. I'm not yet entirely satisfied with the view on mobile, and there's some bad breakpoints, but I will improve that in a separate PR later.

The builds are clickable but are not themselves <a> tags, because we can't have <a> tags inside of other <a> tags.

The content is all of course placeholder stuff.

## Screenshots

![image](https://github.com/user-attachments/assets/52e64f71-e3ca-4c14-a06e-773dc69616ab)

### Hover state
![build-hover](https://github.com/user-attachments/assets/7174d292-c5c6-4937-a38e-043e9b60fbf5)
