### PR TITLE
feat: Add styling for armor and health to statistic bars

### DIFF
--- a/src/lib/components/content/ItemStastisticsBar.svelte
+++ b/src/lib/components/content/ItemStastisticsBar.svelte
@@ -5,9 +5,10 @@
     value: number
     max: number
     icon: string
+    background?: string
   }
 
-  const { label, suffix, value, max, icon }: Props = $props();
+  const { label, suffix, value, max, icon, background = '' }: Props = $props();
 </script>
 
 <div class="statistic">
@@ -16,7 +17,7 @@
       <img src={icon} alt={label} height="24" width="24" />
     </div>
 
-    <div class="progress" style:width="{100 / max * value}%"></div>
+    <div class="progress" style:width="{100 / max * value}%" style:background></div>
   </div>
 
   <div class="value">

--- a/src/lib/components/content/ItemStatistics.svelte
+++ b/src/lib/components/content/ItemStatistics.svelte
@@ -14,7 +14,8 @@
       suffix: "",
       value: 300,
       max: 300,
-      icon: "https://picsum.photos/seed/a/40"
+      icon: "https://picsum.photos/seed/a/40",
+      background: "linear-gradient(to right, #f5f5f5 80%, #f1790e 80%, #f1790e 95%, #19b7df 95%)"
     }, {
       label: "Weapon Power",
       suffix: "%",


### PR DESCRIPTION
## Description

This is a somewhat in-between solution that adds armor and health values to statistics bars, without going to full segmented route like in-game. I do still want to add that at some point since they are easier to read, but for now this is a simple solution using a linear-gradient that still allows us to display the armor and health values in in some.

## Screenshot

![image](https://github.com/user-attachments/assets/474d364d-966e-4d23-8749-449157d1cdd7)
