### PR TITLE
feat: Add round info to build detail page

### DIFF
--- a/src/lib/components/content/RoundInfo.svelte
+++ b/src/lib/components/content/RoundInfo.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import type { RoundInfo } from "$lib/types/build";
+  import Item from "./Item.svelte";
+  import Power from "./Power.svelte";
+
+  interface Props {
+    roundInfo: RoundInfo
+    header: string
+  }
+
+  const { roundInfo, header = "" }: Props = $props();
+
+  const { note, sections } = $derived(roundInfo)
+</script>
+
+<div class="round-info">
+  <h2>{header}</h2>
+
+  <div class="sections">
+    {#each sections as { id, title, power, items } (id)}
+      <div class="section">
+        <div class="section__title">
+          {#if title}
+            <strong>Alternative</strong> - <em>{title}</em>
+          {:else}
+            <strong>Standard</strong>
+          {/if}
+        </div>
+
+        <div class="section__items">
+          {#if power}
+            <Power {power} />
+          {/if}
+
+          {#each items as item (item.id)}
+            <Item {item} />
+          {/each}
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  {#if note}
+    <p class="note">
+      {note}
+    </p>
+  {/if}
+</div>
+
+<style lang="scss">
+  .round-info {
+    --gap: 1rem;
+    margin: calc(var(--gap) * 2) 0 0;
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  h2 {
+    margin: 0 0 var(--gap);
+    font-size: $font-size-h3;
+  }
+
+  .sections {
+    display: grid;
+    gap: var(--gap);
+
+    @include breakpoint(tablet) {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  .section {
+    border: 1px solid $color-border;
+    border-radius: $border-radius;
+  }
+
+  .section__title {
+    padding: 0.25rem 1rem;
+    background: $color-border;
+    border-radius: $border-radius $border-radius 0 0;
+    color: $white;
+    font-size: $font-size-small;
+  }
+
+  .section__items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    padding: 1rem;
+  }
+
+  .note {
+    margin: var(--gap) 0 0;
+  }
+</style>

--- a/src/lib/types/build.d.ts
+++ b/src/lib/types/build.d.ts
@@ -1,9 +1,24 @@
-import type { HeroName } from "./hero"
+import type { HeroData } from "./hero"
 
 // Temporary type, will look different
 export type Build = {
-  hero: HeroName
+  hero: HeroData
   title: string
-  introduction?: string,
+  introduction?: string
+  description?: string
   author: User
+  roundInfos: RoundInfo[]
+}
+
+export type RoundInfo = {
+  id: string
+  note: string
+  sections: RoundInfoSection[]
+}
+
+export type RoundInfoSection = {
+  id: string
+  title: string
+  power: object | null
+  items: object[]
 }

--- a/src/routes/(main)/build/[slug]/+page.svelte
+++ b/src/routes/(main)/build/[slug]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Hero from "$lib/components/content/Hero.svelte";
-	import ItemStatistics from "$lib/components/content/ItemStatistics.svelte";
-	import RoundInfo from "$lib/components/content/RoundInfo.svelte";
+  import ItemStatistics from "$lib/components/content/ItemStatistics.svelte";
+  import RoundInfo from "$lib/components/content/RoundInfo.svelte";
   import { heroes } from "$lib/constants/heroes";
   import type { Build } from "$lib/types/build";
 

--- a/src/routes/(main)/build/[slug]/+page.svelte
+++ b/src/routes/(main)/build/[slug]/+page.svelte
@@ -1,19 +1,135 @@
 <script lang="ts">
   import Hero from "$lib/components/content/Hero.svelte";
 	import ItemStatistics from "$lib/components/content/ItemStatistics.svelte";
+	import RoundInfo from "$lib/components/content/RoundInfo.svelte";
   import { heroes } from "$lib/constants/heroes";
   import type { Build } from "$lib/types/build";
 
   const build: Build = {
     title: "I am a build for a hero",
     introduction: "Some short description, consectetur adipiscing elit. Donec ornare justo quis felis feugiat vestibulum. Nulla facilisi. Aliquam volutpat sed ipsum vel finibus. Morbi diam erat, congue ut gravida vitae.",
+    description: "Some short description, consectetur adipiscing elit. Donec ornare justo quis felis feugiat vestibulum. Nulla facilisi. Aliquam volutpat sed ipsum vel finibus. Morbi diam erat, congue ut gravida vitae.",
     hero: heroes[0],
     author: {
       username: "Some guy"
-    }
+    },
+    roundInfos: [{
+      id: "1",
+      note: "Some short note on the first round",
+      sections: [{
+        id: "1",
+        title: "",
+        power: {
+          id: 1,
+          name: "Some power",
+          description: "I am some description of a power that will appear in the popover",
+          icon: "https://picsum.photos/40"
+        },
+        items: [{
+          id: 1,
+          name: "Some item",
+          description: "I am some description of an item that will appear in the popover",
+          icon: "https://picsum.photos/seed/a/40",
+          rarity: "common",
+          cost: 4000
+        }, {
+          id: 2,
+          name: "Some item",
+          description: "I am some description of an item that will appear in the popover",
+          icon: "https://picsum.photos/seed/b/40",
+          rarity: "rare",
+          cost: 2000
+        }]
+      }, {
+        id: "2",
+        title: "Push maps",
+        power: {
+          id: 1,
+          name: "Some power",
+          description: "I am some description of a power that will appear in the popover",
+          icon: "https://picsum.photos/40"
+        },
+        items: [{
+          id: 1,
+          name: "Some item",
+          description: "I am some description of an item that will appear in the popover",
+          icon: "https://picsum.photos/seed/c/40",
+          rarity: "common",
+          cost: 4000
+        }, {
+          id: 2,
+          name: "Some item",
+          description: "I am some description of an item that will appear in the popover",
+          icon: "https://picsum.photos/seed/d/40",
+          rarity: "rare",
+          cost: 2000
+        }]
+      }]
+    }, {
+      id: "2",
+      note: "Some other short note on the second round",
+      sections: [{
+        id: "1",
+        title: "",
+        power: null,
+        items: [{
+          id: 1,
+          name: "Some item",
+          description: "I am some description of an item that will appear in the popover",
+          icon: "https://picsum.photos/seed/a/40",
+          rarity: "common",
+          cost: 4000
+        }, {
+          id: 2,
+          name: "Some item",
+          description: "I am some description of an item that will appear in the popover",
+          icon: "https://picsum.photos/seed/b/40",
+          rarity: "rare",
+          cost: 2000
+        }]
+      }, {
+        id: "2",
+        title: "Low healing",
+        power: null,
+        items: [{
+          id: 1,
+          name: "Some item",
+          description: "I am some description of an item that will appear in the popover",
+          icon: "https://picsum.photos/seed/c/40",
+          rarity: "common",
+          cost: 4000
+        }, {
+          id: 2,
+          name: "Some item",
+          description: "I am some description of an item that will appear in the popover",
+          icon: "https://picsum.photos/seed/d/40",
+          rarity: "rare",
+          cost: 2000
+        }]
+      }, {
+        id: "3",
+        title: "Other",
+        power: null,
+        items: [{
+          id: 1,
+          name: "Some item",
+          description: "I am some description of an item that will appear in the popover",
+          icon: "https://picsum.photos/seed/c/40",
+          rarity: "common",
+          cost: 4000
+        }, {
+          id: 2,
+          name: "Some item",
+          description: "I am some description of an item that will appear in the popover",
+          icon: "https://picsum.photos/seed/d/40",
+          rarity: "rare",
+          cost: 2000
+        }]
+      }]
+    }]
   }
 
-  const { title, hero, introduction, author } = $derived(build)
+  const { title, hero, introduction, author, roundInfos, description } = $derived(build);
 </script>
 
 <article itemscope itemtype="https://schema.org/Article">
@@ -36,6 +152,16 @@
     </aside>
 
     <section class="article block">
+      {#each roundInfos as roundInfo, i (roundInfo.id)}
+        <RoundInfo {roundInfo} header="Round {i + 1}"  />
+      {/each}
+
+      {#if description}
+        <h2>Description</h2>
+
+        <!-- This will probably be markdown at some point, hence it being a div rather than a p tag -->
+        <div class="description">{description}</div>
+      {/if}
     </section>
   </div>
 </article>
@@ -48,6 +174,14 @@
     &:hover {
       color: $white;
       text-decoration: underline;
+    }
+  }
+
+  h2 {
+    margin: $vertical-offset-large 0 1rem;
+
+    @include breakpoint(tablet) {
+      margin-bottom: 2rem;
     }
   }
 


### PR DESCRIPTION
## Description

Merges into #9, which should be merged first, and this should be rebased

This adds a static version of the round info to the detail page. The contains the individual rounds as well as the description. With a variant for mobile as well.

Once again I made some assuptions for types and suchs. Feel free to totally ignore these, these were just temporary to make development life a little easier.

## Screenshots

![image](https://github.com/user-attachments/assets/149a4bb7-7b91-49fa-ac22-10e3c97f3b77)
![image](https://github.com/user-attachments/assets/9ab37e6c-ad8e-4f9b-8e63-0d46ee9b6a2d)
