### PR TITLE
feat: Add compounded build to sidebar on build detail page

### DIFF
--- a/src/lib/components/content/CompoundedBuild.svelte
+++ b/src/lib/components/content/CompoundedBuild.svelte
@@ -21,6 +21,10 @@
   {#each powers as power (power.id)}
     <Power {power} large />
   {/each}
+
+  {#each { length: 4 - powers.length }}
+    <div class="empty"></div>
+  {/each}
 </div>
 
 <DashedHeader text="Items" />
@@ -28,6 +32,10 @@
 <div class="grid items">
   {#each items as item (item.id)}
     <Item {item} large />
+  {/each}
+
+  {#each { length: 6 - items.length }}
+    <div class="empty item"></div>
   {/each}
 </div>
 
@@ -39,6 +47,20 @@
 
     &.items {
       gap: 2rem;
+    }
+  }
+
+  .empty {
+    width: $power-size-large;
+    height: $power-size-large;
+    background: $color-bg-dark;
+    border-radius: $border-radius;
+    border: 2px solid $color-border;
+
+    &.item {
+      width: $item-size-large;
+      height: $item-size-large;
+      border-radius: 50%;
     }
   }
 </style>

--- a/src/lib/components/content/CompoundedBuild.svelte
+++ b/src/lib/components/content/CompoundedBuild.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Build } from "$lib/types/build";
-  import { getBuildFinalPowers, getBuildFinalItems } from "$lib/utils/build";
+  import { getBuildPowersForRound, getBuildItemsForRound } from "$lib/utils/build";
   import DashedHeader from "./DashedHeader.svelte";
   import Item from "./Item.svelte";
   import Power from "./Power.svelte";
@@ -11,8 +11,8 @@
 
   const { build }: Props = $props();
 
-  const powers = $derived(getBuildFinalPowers(build));
-  const items = $derived(getBuildFinalItems(build));
+  const powers = $derived(getBuildPowersForRound(build));
+  const items = $derived(getBuildItemsForRound(build));
 </script>
 
 <DashedHeader text="Powers" />

--- a/src/lib/components/content/CompoundedBuild.svelte
+++ b/src/lib/components/content/CompoundedBuild.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import type { Build } from "$lib/types/build";
+  import { getBuildFinalPowers, getBuildFinalItems } from "$lib/utils/build";
+  import DashedHeader from "./DashedHeader.svelte";
+  import Item from "./Item.svelte";
+  import Power from "./Power.svelte";
+
+  interface Props {
+    build: Build
+  }
+
+  const { build }: Props = $props();
+
+  const powers = $derived(getBuildFinalPowers(build));
+  const items = $derived(getBuildFinalItems(build));
+</script>
+
+<DashedHeader text="Powers" />
+
+<div class="grid">
+  {#each powers as power (power.id)}
+    <Power {power} large />
+  {/each}
+</div>
+
+<DashedHeader text="Items" />
+
+<div class="grid items">
+  {#each items as item (item.id)}
+    <Item {item} large />
+  {/each}
+</div>
+
+<style lang="scss">
+  .grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+
+    &.items {
+      gap: 2rem;
+    }
+  }
+</style>

--- a/src/lib/components/content/DashedHeader.svelte
+++ b/src/lib/components/content/DashedHeader.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  const { text }: { text: string } = $props();
+</script>
+
+<h2>
+  <div class="dash"></div>
+  <span>{text}</span>
+  <div class="dash"></div>
+</h2>
+
+<style lang="scss">
+  h2 {
+    display: flex;
+    align-items: center;
+    margin: 4rem 0 2rem;
+    font-size: $font-size-h3;
+
+    @include breakpoint(tablet) {
+      margin: 2rem 0 1rem;
+    }
+
+    &:first-child {
+      margin-top: 0;
+    }
+  }
+
+  span {
+    padding: 0 1rem;
+  }
+
+  .dash {
+    height: 2px;
+    width: 100%;
+    background: $color-border;
+  }
+</style>

--- a/src/lib/components/content/Item.svelte
+++ b/src/lib/components/content/Item.svelte
@@ -4,7 +4,7 @@
 
   interface Props {
     item: unknown
-    large: boolean
+    large?: boolean
   }
 
   const { item, large = false }: Props = $props();

--- a/src/lib/components/content/Item.svelte
+++ b/src/lib/components/content/Item.svelte
@@ -1,14 +1,20 @@
-<script>
+<script lang="ts">
   import Popover from "../common/Popover.svelte";
   import SharedDetail from "./SharedDetail.svelte";
 
-  const { item } = $props();
+  interface Props {
+    item: unknown
+    large: boolean
+  }
 
+  const { item, large = false }: Props = $props();
+
+  // @ts-expect-error There's no type right now
   const { name, description, icon, rarity, cost } = $derived(item);
 </script>
 
 <Popover>
-  <div class="item {rarity}">
+  <div class="item {rarity}" class:large>
     <img src={icon} alt={name} />
   </div>
 
@@ -41,6 +47,11 @@
           --color-rarity: #{color.adjust($color, $lightness: 10%)};
         }
       }
+    }
+
+    &.large {
+      width: $item-size-large;
+      height: $item-size-large;
     }
 
     img {

--- a/src/lib/components/content/Power.svelte
+++ b/src/lib/components/content/Power.svelte
@@ -41,6 +41,7 @@
     &.large {
       width: $power-size-large;
       height: $power-size-large;
+      border-radius: $border-radius;
     }
 
     img {

--- a/src/lib/components/content/Power.svelte
+++ b/src/lib/components/content/Power.svelte
@@ -1,14 +1,20 @@
-<script>
+<script lang="ts">
   import Popover from "../common/Popover.svelte";
   import SharedDetail from "./SharedDetail.svelte";
 
-  const { power } = $props();
+  interface Props {
+    power: unknown
+    large: boolean
+  }
 
+  const { power, large = false }: Props = $props();
+
+  // @ts-expect-error There's no type right now
   const { name, description, icon } = $derived(power);
 </script>
 
 <Popover>
-  <div class="power">
+  <div class="power" class:large>
     <img src={icon} alt={name} />
   </div>
 
@@ -32,6 +38,11 @@
       border-color: color.adjust($primary, $lightness: 10%);
     }
 
+    &.large {
+      width: $power-size-large;
+      height: $power-size-large;
+    }
+
     img {
       width: 100%;
       height: auto;
@@ -39,4 +50,5 @@
       border: 1px solid $color-bg-base;
     }
   }
+
 </style>

--- a/src/lib/components/content/Power.svelte
+++ b/src/lib/components/content/Power.svelte
@@ -4,7 +4,7 @@
 
   interface Props {
     power: unknown
-    large: boolean
+    large?: boolean
   }
 
   const { power, large = false }: Props = $props();

--- a/src/lib/data/testData.ts
+++ b/src/lib/data/testData.ts
@@ -1,0 +1,229 @@
+export const testDataRoundInfos = [
+  {
+    id: "1",
+    note: "Some short note on the first round",
+    sections: [
+      {
+        id: "1",
+        title: "",
+        power: {
+          id: 1,
+          name: "Some power",
+          description: "I am some description of a power that will appear in the popover",
+          icon: "https://picsum.photos/40",
+        },
+        items: [
+          {
+            id: 1,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/a/40",
+            rarity: "common",
+            cost: 4000,
+          },
+          {
+            id: 2,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/b/40",
+            rarity: "rare",
+            cost: 2000,
+          },
+        ],
+      },
+      {
+        id: "2",
+        title: "Push maps",
+        power: {
+          id: 1,
+          name: "Some power",
+          description: "I am some description of a power that will appear in the popover",
+          icon: "https://picsum.photos/40",
+        },
+        items: [
+          {
+            id: 1,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/c/40",
+            rarity: "common",
+            cost: 4000,
+          },
+          {
+            id: 2,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/d/40",
+            rarity: "rare",
+            cost: 2000,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "2",
+    note: "Some other short note on the second round",
+    sections: [
+      {
+        id: "1",
+        title: "",
+        power: null,
+        items: [
+          {
+            id: 3,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/a/40",
+            rarity: "common",
+            cost: 4000,
+          },
+          {
+            id: 4,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/b/40",
+            rarity: "rare",
+            cost: 2000,
+          },
+        ],
+      },
+      {
+        id: "2",
+        title: "Low healing",
+        power: null,
+        items: [
+          {
+            id: 1,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/c/40",
+            rarity: "common",
+            cost: 4000,
+          },
+          {
+            id: 2,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/d/40",
+            rarity: "rare",
+            cost: 2000,
+          },
+        ],
+      },
+      {
+        id: "3",
+        title: "Other",
+        power: null,
+        items: [
+          {
+            id: 1,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/c/40",
+            rarity: "common",
+            cost: 4000,
+          },
+          {
+            id: 2,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/d/40",
+            rarity: "rare",
+            cost: 2000,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "3",
+    note: "Some other short note on the second round",
+    sections: [
+      {
+        id: "1",
+        title: "",
+        power: {
+          id: 2,
+          name: "Some power",
+          description: "I am some description of a power that will appear in the popover",
+          icon: "https://picsum.photos/40",
+        },
+        items: [
+          {
+            id: 5,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/g/40",
+            rarity: "common",
+            cost: 4000,
+          },
+          {
+            id: 6,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/h/40",
+            rarity: "rare",
+            cost: 2000,
+          },
+        ],
+      },
+      {
+        id: "2",
+        title: "Low healing",
+        power: {
+          id: 2,
+          name: "Some power",
+          description: "I am some description of a power that will appear in the popover",
+          icon: "https://picsum.photos/40",
+        },
+        items: [
+          {
+            id: 1,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/i/40",
+            rarity: "common",
+            cost: 4000,
+          },
+          {
+            id: 2,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/j/40",
+            rarity: "rare",
+            cost: 2000,
+          },
+        ],
+      },
+      {
+        id: "3",
+        title: "Other",
+        power: {
+          id: 2,
+          name: "Some power",
+          description: "I am some description of a power that will appear in the popover",
+          icon: "https://picsum.photos/40",
+        },
+        items: [
+          {
+            id: 1,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/k/40",
+            rarity: "common",
+            cost: 4000,
+          },
+          {
+            id: 2,
+            name: "Some item",
+            description: "I am some description of an item that will appear in the popover",
+            icon: "https://picsum.photos/seed/l/40",
+            rarity: "rare",
+            cost: 2000,
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/src/lib/scss/_variables.scss
+++ b/src/lib/scss/_variables.scss
@@ -40,6 +40,8 @@ $gutter: 1.5rem;
 $vertical-offset-large: clamp($gutter, 10vw, 7.5rem);
 $navigation-height: 5rem;
 $item-size: #{px-to-rem(40)};
+$item-size-large: #{px-to-rem(80)};
+$power-size-large: 4rem;
 
 $border-radius: 1rem;
 $border-radius-small: $border-radius * 0.5;

--- a/src/lib/utils/build.ts
+++ b/src/lib/utils/build.ts
@@ -1,0 +1,38 @@
+import type { Build, RoundInfo, RoundInfoSection } from "$lib/types/build";
+
+// TODO: Replace unknown type with Power[] type
+export function getBuildFinalPowers(build: Build): unknown[] {
+  const powers: unknown[] = [];
+
+  getBuildStandardSections(build).forEach(({ power }) => {
+    if (power) powers.push(power);
+  });
+
+  return powers;
+}
+
+// TODO: Replace unknown type with Power[] type
+export function getBuildFinalItems(build: Build): unknown[] {
+  const items: unknown[] = [];
+
+  getBuildStandardSections(build).forEach((section) => {
+    items.push(...section.items);
+  });
+
+  return items;
+}
+
+export function getBuildFinalCost(build: Build): number {
+  return getBuildFinalItems(build).reduce((sum, item) => sum + item.cost, 0);
+}
+
+/** @returns All standard section of a build, excluding all "alternative" options */
+export function getBuildStandardSections(build: Build): RoundInfoSection[] {
+  const sections: RoundInfoSection[] = [];
+
+  build.roundInfos.forEach((roundInfo: RoundInfo) => {
+    sections.push(...roundInfo.sections.filter((section) => !section.title));
+  });
+
+  return sections;
+}

--- a/src/lib/utils/build.ts
+++ b/src/lib/utils/build.ts
@@ -1,10 +1,10 @@
 import type { Build, RoundInfo, RoundInfoSection } from "$lib/types/build";
 
 // TODO: Replace unknown type with Power[] type
-export function getBuildFinalPowers(build: Build): unknown[] {
+export function getBuildPowersForRound(build: Build, round = 7): unknown[] {
   const powers: unknown[] = [];
 
-  getBuildStandardSections(build).forEach(({ power }) => {
+  getBuildStandardSectionsForRound(build, round).forEach(({ power }) => {
     if (power) powers.push(power);
   });
 
@@ -12,25 +12,25 @@ export function getBuildFinalPowers(build: Build): unknown[] {
 }
 
 // TODO: Replace unknown type with Power[] type
-export function getBuildFinalItems(build: Build): unknown[] {
+export function getBuildItemsForRound(build: Build, round = 7): unknown[] {
   const items: unknown[] = [];
 
-  getBuildStandardSections(build).forEach((section) => {
+  getBuildStandardSectionsForRound(build, round).forEach((section) => {
     items.push(...section.items);
   });
 
   return items;
 }
 
-export function getBuildFinalCost(build: Build): number {
-  return getBuildFinalItems(build).reduce((sum, item) => sum + item.cost, 0);
+export function getBuildCostForRound(build: Build, round = 7): number {
+  return getBuildItemsForRound(build, round).reduce((sum, item) => sum + item.cost, 0);
 }
 
-/** @returns All standard section of a build, excluding all "alternative" options */
-export function getBuildStandardSections(build: Build): RoundInfoSection[] {
+/** @returns All standard section of a build up to a certain round, excluding all "alternative" options */
+export function getBuildStandardSectionsForRound(build: Build, round = 7): RoundInfoSection[] {
   const sections: RoundInfoSection[] = [];
 
-  build.roundInfos.forEach((roundInfo: RoundInfo) => {
+  build.roundInfos.slice(0, round).forEach((roundInfo: RoundInfo) => {
     sections.push(...roundInfo.sections.filter((section) => !section.title));
   });
 

--- a/src/routes/(main)/build/[slug]/+page.svelte
+++ b/src/routes/(main)/build/[slug]/+page.svelte
@@ -7,7 +7,7 @@
   import { heroes } from "$lib/constants/heroes";
   import { testDataRoundInfos } from "$lib/data/testData";
   import type { Build } from "$lib/types/build";
-  import { getBuildFinalCost } from "$lib/utils/build";
+  import { getBuildCostForRound } from "$lib/utils/build";
 
   const build: Build = {
     title: "I am a build for a hero",
@@ -43,7 +43,7 @@
     <aside class="sidebar block">
       <CompoundedBuild {build} />
 
-      <h2>Build cost: {getBuildFinalCost(build).toLocaleString()}</h2>
+      <h2>Build cost: {getBuildCostForRound(build).toLocaleString()}</h2>
 
       <DashedHeader text="Stats" />
       <ItemStatistics items={[]} {hero} />

--- a/src/routes/(main)/build/[slug]/+page.svelte
+++ b/src/routes/(main)/build/[slug]/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
+  import CompoundedBuild from "$lib/components/content/CompoundedBuild.svelte";
+  import DashedHeader from "$lib/components/content/DashedHeader.svelte";
   import Hero from "$lib/components/content/Hero.svelte";
   import ItemStatistics from "$lib/components/content/ItemStatistics.svelte";
   import RoundInfo from "$lib/components/content/RoundInfo.svelte";
   import { heroes } from "$lib/constants/heroes";
+  import { testDataRoundInfos } from "$lib/data/testData";
   import type { Build } from "$lib/types/build";
+  import { getBuildFinalCost } from "$lib/utils/build";
 
   const build: Build = {
     title: "I am a build for a hero",
@@ -15,145 +19,7 @@
     author: {
       username: "Some guy",
     },
-    roundInfos: [
-      {
-        id: "1",
-        note: "Some short note on the first round",
-        sections: [
-          {
-            id: "1",
-            title: "",
-            power: {
-              id: 1,
-              name: "Some power",
-              description: "I am some description of a power that will appear in the popover",
-              icon: "https://picsum.photos/40",
-            },
-            items: [
-              {
-                id: 1,
-                name: "Some item",
-                description: "I am some description of an item that will appear in the popover",
-                icon: "https://picsum.photos/seed/a/40",
-                rarity: "common",
-                cost: 4000,
-              },
-              {
-                id: 2,
-                name: "Some item",
-                description: "I am some description of an item that will appear in the popover",
-                icon: "https://picsum.photos/seed/b/40",
-                rarity: "rare",
-                cost: 2000,
-              },
-            ],
-          },
-          {
-            id: "2",
-            title: "Push maps",
-            power: {
-              id: 1,
-              name: "Some power",
-              description: "I am some description of a power that will appear in the popover",
-              icon: "https://picsum.photos/40",
-            },
-            items: [
-              {
-                id: 1,
-                name: "Some item",
-                description: "I am some description of an item that will appear in the popover",
-                icon: "https://picsum.photos/seed/c/40",
-                rarity: "common",
-                cost: 4000,
-              },
-              {
-                id: 2,
-                name: "Some item",
-                description: "I am some description of an item that will appear in the popover",
-                icon: "https://picsum.photos/seed/d/40",
-                rarity: "rare",
-                cost: 2000,
-              },
-            ],
-          },
-        ],
-      },
-      {
-        id: "2",
-        note: "Some other short note on the second round",
-        sections: [
-          {
-            id: "1",
-            title: "",
-            power: null,
-            items: [
-              {
-                id: 1,
-                name: "Some item",
-                description: "I am some description of an item that will appear in the popover",
-                icon: "https://picsum.photos/seed/a/40",
-                rarity: "common",
-                cost: 4000,
-              },
-              {
-                id: 2,
-                name: "Some item",
-                description: "I am some description of an item that will appear in the popover",
-                icon: "https://picsum.photos/seed/b/40",
-                rarity: "rare",
-                cost: 2000,
-              },
-            ],
-          },
-          {
-            id: "2",
-            title: "Low healing",
-            power: null,
-            items: [
-              {
-                id: 1,
-                name: "Some item",
-                description: "I am some description of an item that will appear in the popover",
-                icon: "https://picsum.photos/seed/c/40",
-                rarity: "common",
-                cost: 4000,
-              },
-              {
-                id: 2,
-                name: "Some item",
-                description: "I am some description of an item that will appear in the popover",
-                icon: "https://picsum.photos/seed/d/40",
-                rarity: "rare",
-                cost: 2000,
-              },
-            ],
-          },
-          {
-            id: "3",
-            title: "Other",
-            power: null,
-            items: [
-              {
-                id: 1,
-                name: "Some item",
-                description: "I am some description of an item that will appear in the popover",
-                icon: "https://picsum.photos/seed/c/40",
-                rarity: "common",
-                cost: 4000,
-              },
-              {
-                id: 2,
-                name: "Some item",
-                description: "I am some description of an item that will appear in the popover",
-                icon: "https://picsum.photos/seed/d/40",
-                rarity: "rare",
-                cost: 2000,
-              },
-            ],
-          },
-        ],
-      },
-    ],
+    roundInfos: testDataRoundInfos
   };
 
   const { title, hero, introduction, author, roundInfos, description } = $derived(build);
@@ -175,6 +41,11 @@
 
   <div class="layout">
     <aside class="sidebar block">
+      <CompoundedBuild {build} />
+
+      <h2>Build cost: {getBuildFinalCost(build).toLocaleString()}</h2>
+
+      <DashedHeader text="Stats" />
       <ItemStatistics items={[]} {hero} />
     </aside>
 
@@ -205,10 +76,12 @@
   }
 
   h2 {
-    margin: $vertical-offset-large 0 1rem;
+    margin: 2rem 0;
+    color: $secondary;
+    text-align: center;
 
     @include breakpoint(tablet) {
-      margin-bottom: 2rem;
+      margin: 4rem 0;
     }
   }
 

--- a/src/routes/(main)/build/[slug]/+page.svelte
+++ b/src/routes/(main)/build/[slug]/+page.svelte
@@ -43,7 +43,7 @@
     <aside class="sidebar block">
       <CompoundedBuild {build} />
 
-      <h2>Build cost: {getBuildCostForRound(build).toLocaleString()}</h2>
+      <h2 class="build-cost">Build cost: {getBuildCostForRound(build, 1).toLocaleString()}</h2>
 
       <DashedHeader text="Stats" />
       <ItemStatistics items={[]} {hero} />
@@ -76,12 +76,10 @@
   }
 
   h2 {
-    margin: 2rem 0;
-    color: $secondary;
-    text-align: center;
+    margin: $vertical-offset-large 0 1rem;
 
     @include breakpoint(tablet) {
-      margin: 4rem 0;
+      margin-bottom: 2rem;
     }
   }
 
@@ -134,5 +132,15 @@
 
   .sidebar {
     min-height: 20rem;
+  }
+
+  .build-cost {
+    margin: 2rem 0;
+    color: $secondary;
+    text-align: center;
+
+    @include breakpoint(tablet) {
+      margin: 4rem 0;
+    }
   }
 </style>


### PR DESCRIPTION
## Description

This adds the "final" build to the sidebar of the detail page. This final build is derived from the items and powers per section, adding them up.
- There's not yet any logic for sold items.
- Types in the new `utils/build` function are not quite right because we don't have the actual types yet.

To make sure the grid is always filled out, we add skeletons to indicate that something _will_ be there in later rounds. In final rounds we'd expect all slots to be filled.

## Screenshots
![image](https://github.com/user-attachments/assets/1ce4a06e-6c61-41ee-905c-9ed335336104)

This build can already be narrowed down by round, but there's no controls for it yet. For example, this is round 1 of the same build above. It uses the exact same dataset, the shown build is derived from the build itself and the round number.

![image](https://github.com/user-attachments/assets/059126e5-ddb2-4540-82ff-058ee63d3a84)
