### PR TITLE
feat: Add round selector 

### DIFF
--- a/src/lib/components/content/Build.svelte
+++ b/src/lib/components/content/Build.svelte
@@ -1,25 +1,25 @@
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { heroes } from "$lib/constants/heroes";
+  import type { Build } from "$lib/types/build";
+  import type { CurrentRound } from "$lib/types/round";
+  import { getContext } from "svelte";
   import Hero from "./Hero.svelte";
   import Item from "./Item.svelte";
   import Power from "./Power.svelte";
+  import { getBuildItemsForRound, getBuildPowersForRound } from "$lib/utils/build";
+  import { slide } from "svelte/transition";
 
-  const power = (id: number) => ({
-    id,
-    name: "Some power",
-    description: "I am some description of a power that will appear in the popover",
-    icon: `https://picsum.photos/seed/${id}/40`,
-  });
+  interface Props {
+    build: Build
+  }
 
-  const item = (id: number) => ({
-    id,
-    name: "Some power",
-    description: "I am some description of a power that will appear in the popover",
-    icon: `https://picsum.photos/seed/${id}/40`,
-    rarity: "rare",
-    cost: 2000 * id,
-  });
+  const { build }: Props = $props();
+
+  const currentRound: CurrentRound = getContext('currentRound');
+
+  const items = $derived(getBuildItemsForRound(build, currentRound.value));
+  const powers = $derived(getBuildPowersForRound(build, currentRound.value));
 
   const href = "/build/test";
 
@@ -48,12 +48,16 @@
   </div>
 
   <div class="items">
-    {#each { length: 4 }, i}
-      <Power power={power(i + 1)} />
+    {#each powers as power (power.id)}
+      <div transition:slide={{ duration: 100, axis: 'x' }}>
+        <Power {power} />
+      </div>
     {/each}
 
-    {#each { length: 6 }, i}
-      <Item item={item(i + 10)} />
+    {#each items as item (item.id)}
+      <div transition:slide={{ duration: 100, axis: 'x' }}>
+        <Item {item} />
+      </div>
     {/each}
   </div>
 </div>

--- a/src/lib/components/content/BuildsList.svelte
+++ b/src/lib/components/content/BuildsList.svelte
@@ -1,24 +1,68 @@
 <script lang="ts">
+  import { heroes } from "$lib/constants/heroes";
+  import { testDataRoundInfos } from "$lib/data/testData";
   import Build from "./Build.svelte";
+  import { type Build as BuildType } from "$lib/types/build";
+  import RoundSelector from "./RoundSelector.svelte";
 
   interface Props {
     header: string;
   }
 
   const { header }: Props = $props();
+
+  // Temp
+  const build: BuildType = {
+    title: "I am a build for a hero",
+    introduction:
+      "Some short description, consectetur adipiscing elit. Donec ornare justo quis felis feugiat vestibulum. Nulla facilisi. Aliquam volutpat sed ipsum vel finibus. Morbi diam erat, congue ut gravida vitae.",
+    description:
+      "Some short description, consectetur adipiscing elit. Donec ornare justo quis felis feugiat vestibulum. Nulla facilisi. Aliquam volutpat sed ipsum vel finibus. Morbi diam erat, congue ut gravida vitae.",
+    hero: heroes[0],
+    author: {
+      username: "Some guy",
+    },
+    roundInfos: testDataRoundInfos
+  };
 </script>
 
-<h1>{header}</h1>
+<header class="header">
+  <h1>{header}</h1>
+
+  <div class="round-selector">
+    <RoundSelector />
+  </div>
+</header>
 
 <div class="block list">
-  <Build />
-  <Build />
-  <Build />
+  <Build {build} />
+  <Build {build} />
+  <Build {build} />
 </div>
 
 <style lang="scss">
   h1 {
+    margin: 0;
+  }
+
+  .header {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
     margin: $vertical-offset-large 0 1rem;
+
+    @include breakpoint(tablet) {
+      flex-direction: row;
+      align-items: flex-end;
+      justify-content: space-between;
+    }
+  }
+
+  .round-selector {
+    margin: 0.5rem 0 0;
+    @include breakpoint(tablet) {
+      margin: 0 0 0.75rem;
+    }
   }
 
   .list {

--- a/src/lib/components/content/CompoundedBuild.svelte
+++ b/src/lib/components/content/CompoundedBuild.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import type { Build } from "$lib/types/build";
+  import type { CurrentRound } from "$lib/types/round";
   import { getBuildPowersForRound, getBuildItemsForRound } from "$lib/utils/build";
+  import { getContext } from "svelte";
   import DashedHeader from "./DashedHeader.svelte";
   import Item from "./Item.svelte";
   import Power from "./Power.svelte";
+  import { scale } from "svelte/transition";
 
   interface Props {
     build: Build
@@ -11,15 +14,19 @@
 
   const { build }: Props = $props();
 
-  const powers = $derived(getBuildPowersForRound(build));
-  const items = $derived(getBuildItemsForRound(build));
+  const currentRound: CurrentRound = getContext('currentRound');
+
+  const powers = $derived(getBuildPowersForRound(build, currentRound.value));
+  const items = $derived(getBuildItemsForRound(build, currentRound.value));
 </script>
 
 <DashedHeader text="Powers" />
 
 <div class="grid">
   {#each powers as power (power.id)}
-    <Power {power} large />
+    <div in:scale={{ duration: 50, start: 0.75 }}>
+      <Power {power} large />
+    </div>
   {/each}
 
   {#each { length: 4 - powers.length }}
@@ -31,7 +38,9 @@
 
 <div class="grid items">
   {#each items as item (item.id)}
-    <Item {item} large />
+    <div in:scale={{ duration: 50, start: 0.75 }}>
+      <Item {item} large />
+    </div>
   {/each}
 
   {#each { length: 6 - items.length }}

--- a/src/lib/components/content/RoundSelector.svelte
+++ b/src/lib/components/content/RoundSelector.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  import { ROUND_MAX, ROUND_MIN } from "$lib/constants/round";
+  import type { CurrentRound } from "$lib/types/round";
+  import { getContext } from "svelte";
+
+  // The round is passed via a context state rune. This is done to prevent having to pass the round
+  // down through many components if the components happens to be quite deep.
+  const currentRound: CurrentRound = getContext('currentRound');
+
+  function setCurrentRound(incrementor: 1 | -1): void {
+    if (!currentRound) {
+      console.error('No round was passed as context');
+      return;
+    }
+
+    currentRound.value = Math.min(Math.max(currentRound.value + incrementor, ROUND_MIN), ROUND_MAX);
+  }
+</script>
+
+<div class="round-selector">
+  <button class="control" disabled={currentRound.value === ROUND_MIN}  onclick={() => setCurrentRound(-1)}>
+    &lt;
+  </button>
+
+  <span>
+    {#if currentRound.value < ROUND_MAX}
+      Round <em>{currentRound.value}</em>
+    {:else}
+      Final build
+    {/if}
+  </span>
+
+  <button class="control" disabled={currentRound.value === ROUND_MAX} onclick={() => setCurrentRound(1)}>
+    &gt;
+  </button>
+</div>
+
+<style lang="scss">
+  $control-size: 2rem;
+
+  // Force monospace size to prevent text from jumping around between different rounds
+  em {
+    font-variant-numeric: tabular-nums;
+    font-style: normal;
+  }
+
+  .round-selector {
+    display: grid;
+    grid-template-columns: $control-size 8rem $control-size;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: $secondary;
+    font-family: $font-stack-brand;
+  }
+
+  .control {
+    height: $control-size;
+    width: $control-size;
+    border: 2px solid $color-border;
+    box-shadow: inset 0 0 0 1px $color-bg-base;
+    border-radius: $border-radius-small;
+    background: $color-border;
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
+    cursor: pointer;
+    transition: opacity 100ms, color 100ms;
+
+    &[disabled] {
+      opacity: 0.35;
+      color: $color-text-alt;
+    }
+  }
+</style>

--- a/src/lib/constants/round.ts
+++ b/src/lib/constants/round.ts
@@ -1,0 +1,2 @@
+export const ROUND_MIN = 1;
+export const ROUND_MAX = 7;

--- a/src/lib/types/round.ts
+++ b/src/lib/types/round.ts
@@ -1,0 +1,1 @@
+export type CurrentRound = { value: number }

--- a/src/lib/types/round.ts
+++ b/src/lib/types/round.ts
@@ -1,1 +1,1 @@
-export type CurrentRound = { value: number }
+export type CurrentRound = { value: number };

--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -1,8 +1,15 @@
-<script>
+<script lang="ts">
   import Heroes from "$lib/components/content/Heroes.svelte";
   import Power from "$lib/components/content/Power.svelte";
   import Item from "$lib/components/content/Item.svelte";
   import BuildsList from "$lib/components/content/BuildsList.svelte";
+  import type { CurrentRound } from "$lib/types/round";
+  import { ROUND_MAX } from "$lib/constants/round";
+  import { setContext } from "svelte";
+
+  const currentRound: CurrentRound = $state({ value: ROUND_MAX });
+
+  setContext('currentRound', currentRound);
 
   // Placeholder stuff
   const items = [
@@ -44,6 +51,7 @@
 
 <Heroes />
 
+<BuildsList header="Popular Builds" />
 <BuildsList header="Latest Builds" />
 
 <div class="block vertical-offset-large">

--- a/src/routes/(main)/build/[slug]/+page.svelte
+++ b/src/routes/(main)/build/[slug]/+page.svelte
@@ -4,10 +4,18 @@
   import Hero from "$lib/components/content/Hero.svelte";
   import ItemStatistics from "$lib/components/content/ItemStatistics.svelte";
   import RoundInfo from "$lib/components/content/RoundInfo.svelte";
+  import RoundSelector from "$lib/components/content/RoundSelector.svelte";
   import { heroes } from "$lib/constants/heroes";
+  import { ROUND_MAX } from "$lib/constants/round";
   import { testDataRoundInfos } from "$lib/data/testData";
   import type { Build } from "$lib/types/build";
+  import type { CurrentRound } from "$lib/types/round";
   import { getBuildCostForRound } from "$lib/utils/build";
+  import { setContext } from "svelte";
+
+  const currentRound: CurrentRound = $state({ value: ROUND_MAX });
+
+  setContext('currentRound', currentRound);
 
   const build: Build = {
     title: "I am a build for a hero",
@@ -41,6 +49,8 @@
 
   <div class="layout">
     <aside class="sidebar block">
+      <RoundSelector />
+
       <CompoundedBuild {build} />
 
       <h2 class="build-cost">Build cost: {getBuildCostForRound(build, 1).toLocaleString()}</h2>


### PR DESCRIPTION
## Description

Merges into #14, which should be merged first

This PR adds a round selector to both the detail and homepage. The rounds are passed and set via a state rune in setContext. This is done rather than a global store to make it easier to manage per page. With it being a state on the page itself, the value is shared between anything on the page that might use it. On the homepage this is relevant for the different build lists.

## Screenshots

![round-selector-home](https://github.com/user-attachments/assets/6ff756dd-c7f2-4d7d-8f40-f717aab8cabb)
![round-selector-detail](https://github.com/user-attachments/assets/f0e9c672-b089-4015-a37c-c02fd68577b2)
