### PR TITLE
feat: Allow popover to be closed via outside click or escape

### DIFF
--- a/src/lib/actions/closeable.ts
+++ b/src/lib/actions/closeable.ts
@@ -1,0 +1,25 @@
+import type { Action } from "svelte/action";
+
+export const closeable: Action<Node, { onclose?: () => void }> = (node, { onclose = () => null } = {}) => {
+  function click(event: MouseEvent): void {
+    if (event.target instanceof Node && node.contains(event.target)) return;
+
+    onclose();
+  }
+
+  function keydown(event: KeyboardEvent): void {
+    if (event.code !== "Escape") return;
+
+    onclose();
+  }
+
+  window.addEventListener("click", click);
+  window.addEventListener("keydown", keydown);
+
+  return {
+    destroy() {
+      window.removeEventListener("click", click);
+      window.removeEventListener("keydown", keydown);
+    }
+  };
+};

--- a/src/lib/actions/closeable.ts
+++ b/src/lib/actions/closeable.ts
@@ -1,6 +1,9 @@
 import type { Action } from "svelte/action";
 
-export const closeable: Action<Node, { onclose?: () => void }> = (node, { onclose = () => null } = {}) => {
+export const closeable: Action<Node, { onclose?: () => void }> = (
+  node,
+  { onclose = () => null } = {},
+) => {
   function click(event: MouseEvent): void {
     if (event.target instanceof Node && node.contains(event.target)) return;
 
@@ -20,6 +23,6 @@ export const closeable: Action<Node, { onclose?: () => void }> = (node, { onclos
     destroy() {
       window.removeEventListener("click", click);
       window.removeEventListener("keydown", keydown);
-    }
+    },
   };
 };

--- a/src/lib/components/common/Popover.svelte
+++ b/src/lib/components/common/Popover.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { closeable } from "$lib/actions/closeable";
   import { fly } from "svelte/transition";
 
   const { children, content } = $props();
@@ -12,6 +13,7 @@
     onmouseenter={() => (active = true)}
     onmouseleave={() => (active = false)}
     onclick={() => (active = !active)}
+    use:closeable={{ onclose: () => active = false }}
   >
     {@render children()}
   </button>


### PR DESCRIPTION
## Description

On desktop the interaction is a simple hover, and closing the popover doesn't require extra actions. With touch screens, however, that is a bit different. The popovers are opened on tap, and closed by tapping the same element. This PR adds another way, and that is by tapping anywhere but the element itself. Or pressing escape, for good measure.