### PR TITLE
fix: Re-position popover if it open offscreen

### DIFF
--- a/src/lib/components/common/Popover.svelte
+++ b/src/lib/components/common/Popover.svelte
@@ -1,9 +1,30 @@
 <script lang="ts">
+  import { tick } from "svelte";
   import { fly } from "svelte/transition";
 
   const { children, content } = $props();
 
   let active = $state(false);
+  let element: HTMLElement | null = $state(null);
+  let offset = $state(0);
+
+  $effect(() => {
+    if (active) positionPopover();
+  });
+
+  async function positionPopover(): Promise<void> {
+    if (!element) return;
+
+    offset = 0;
+
+    await tick();
+
+    const { left, right } = element.getBoundingClientRect();
+    const gap = parseInt(getComputedStyle(document.documentElement).fontSize);
+
+    if (left - gap < 0) offset = left - gap;
+    else if (right - window.innerWidth + gap > 0) offset = right - window.innerWidth + gap;
+  }
 </script>
 
 <div class="popover">
@@ -17,7 +38,7 @@
   </button>
 
   {#if active}
-    <div class="content" transition:fly={{ y: 10, duration: 50 }}>
+    <div class="content" transition:fly={{ y: 10, duration: 50 }} bind:this={element} style:--offset="{offset}px">
       {@render content()}
     </div>
   {/if}
@@ -41,7 +62,7 @@
     z-index: 10;
     position: absolute;
     bottom: -1rem;
-    left: 50%;
+    left: calc(50% - var(--offset));
     transform: translateX(-50%) translateY(100%);
     background: $color-bg-dark;
     border-radius: $border-radius;

--- a/src/lib/components/content/SharedDetail.svelte
+++ b/src/lib/components/content/SharedDetail.svelte
@@ -23,7 +23,7 @@
 
 <style lang="scss">
   .detail {
-    width: 23rem;
+    width: min(calc(100vw - 2rem), 23rem);
     padding: 1.5rem;
   }
 


### PR DESCRIPTION
## Description

When the popover opens it might be displayed partially offscreen. This commit fixes that by repositioning it if that happens, with different calculations for left and right.

## Screenshots

![popover-reposition](https://github.com/user-attachments/assets/ec627df6-2642-43c0-b892-9742d6eb0fbf)
