### PR TITLE
feat: Set up simple state for currentUser

### DIFF
--- a/prisma/migrations/20250429035827_add_user/migration.sql
+++ b/prisma/migrations/20250429035827_add_user/migration.sql
@@ -1,0 +1,42 @@
+/*
+  Warnings:
+
+  - The `rarity` column on the `Item` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - Changed the type of `role` on the `Hero` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Changed the type of `category` on the `Item` table. No cast exists, the column would be dropped and recreated, which cannot be done if there is data, since the column is required.
+  - Added the required column `authorId` to the `StadiumBuild` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Hero" DROP COLUMN "role",
+ADD COLUMN     "role" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Item" DROP COLUMN "rarity",
+ADD COLUMN     "rarity" TEXT NOT NULL DEFAULT 'common',
+DROP COLUMN "category",
+ADD COLUMN     "category" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "StadiumBuild" ADD COLUMN     "authorId" TEXT NOT NULL;
+
+-- DropEnum
+DROP TYPE "HeroRole";
+
+-- DropEnum
+DROP TYPE "ItemCategory";
+
+-- DropEnum
+DROP TYPE "ItemRarity";
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "oauthId" UUID NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "StadiumBuild" ADD CONSTRAINT "StadiumBuild_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,10 +23,19 @@ model Hero {
   items  Item[]
 }
 
+model User {
+  id       String         @id @default(cuid(2))
+  username String
+  oauthId  String         @db.Uuid
+  builds   StadiumBuild[]
+}
+
 model StadiumBuild {
   id              String      @id @default(cuid(2))
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt
+  author          User        @relation(fields: [authorId], references: [id])
+  authorId        String
   buildTitle      String      @db.VarChar(63)
   description     String?
   roundInfos      RoundInfo[]

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -52,7 +52,10 @@ async function createStats(tx: PrismaTransaction) {
 
 async function createHeroes(tx: PrismaTransaction) {
   return await tx.hero.createManyAndReturn({
-    data: heroes,
+    data: heroes.map((heroData) => ({
+      name: heroData.name as string,
+      role: heroData.role as string,
+    })),
   });
 }
 

--- a/src/lib/components/layout/Navigation.svelte
+++ b/src/lib/components/layout/Navigation.svelte
@@ -3,7 +3,7 @@
   import UserMenu from "$lib/components/user/UserMenu.svelte";
   import { getContext } from "svelte";
   import { api } from "$lib/utils/api";
-  import { type User } from "$lib/types/user";
+  import type { User } from "$src/generated/prisma";
   import { invalidateAll } from "$app/navigation";
 
   const currentUser = getContext("currentUser");

--- a/src/lib/components/layout/Navigation.svelte
+++ b/src/lib/components/layout/Navigation.svelte
@@ -1,6 +1,17 @@
 <script lang="ts">
   import imageLogo from "$lib/images/logo.webp";
   import UserMenu from "$lib/components/user/UserMenu.svelte";
+  import { getContext } from "svelte";
+  import { api } from "$lib/utils/api";
+  import { type User } from "$lib/types/user";
+  import { invalidateAll } from "$app/navigation";
+
+  const currentUser = getContext("currentUser");
+
+  async function login() {
+    await api<User>("login");
+    invalidateAll();
+  }
 </script>
 
 <nav>
@@ -9,7 +20,11 @@
       <img src={imageLogo} height="64" width="175" alt="OW Armory" />
     </a>
 
-    <UserMenu />
+    {#if currentUser}
+      <UserMenu />
+    {:else}
+      <button onclick={login}>Log in</button>
+    {/if}
   </div>
 </nav>
 

--- a/src/lib/components/user/UserMenu.svelte
+++ b/src/lib/components/user/UserMenu.svelte
@@ -1,8 +1,22 @@
-<script lang="scss">
+<script lang="ts">
+  import { invalidateAll } from "$app/navigation";
+  import type { User } from "$lib/types/user";
+  import { api } from "$lib/utils/api";
+  import { getContext } from "svelte";
+
+  const currentUser: User = getContext('currentUser');
+
+  // This function is temporary, the log out will be moved to the /account page
+  async function logout(event: MouseEvent) {
+    event.preventDefault();
+
+    await api<User>("logout");
+    invalidateAll();
+  }
 </script>
 
-<a href="/profile" class="avatar">
-  <img src="//:0" alt="Username" height="64" width="64" />
+<a href="/account" class="avatar" onclick={logout}>
+  <img src="//:0" alt={currentUser.username} height="64" width="64" />
 </a>
 
 <style lang="scss">

--- a/src/lib/constants/auth.ts
+++ b/src/lib/constants/auth.ts
@@ -1,1 +1,1 @@
-export const AUTH_TOKEN_COOKIE_NAME = 'auth-token';
+export const AUTH_TOKEN_COOKIE_NAME = "auth-token";

--- a/src/lib/constants/auth.ts
+++ b/src/lib/constants/auth.ts
@@ -1,0 +1,1 @@
+export const AUTH_TOKEN_COOKIE_NAME = 'auth-token';

--- a/src/lib/types/user.d.ts
+++ b/src/lib/types/user.d.ts
@@ -1,4 +1,0 @@
-// Temporary type, will look different
-export type User = {
-  username: string;
-};

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -1,0 +1,11 @@
+export async function api<T>(path: string, serverFetch = null): Promise<T | null> {
+  try {
+    const response = await (serverFetch || fetch)(`/api/${path}`);
+    const parsed = await response.json();
+
+    return parsed;
+  } catch (error: unknown) {
+    console.error(error);
+    return null;
+  }
+}

--- a/src/routes/(main)/+layout.svelte
+++ b/src/routes/(main)/+layout.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
-  import type { Snippet } from "svelte";
+  import { setContext, type Snippet } from "svelte";
   import Navigation from "$lib/components/layout/Navigation.svelte";
   import PageBackground from "$lib/components/layout/PageBackground.svelte";
+  import type { PageData } from "./$types";
 
-  const { children }: { children: Snippet } = $props();
+  const { data, children }: { data: PageData; children: Snippet } = $props();
+
+  setContext("currentUser", data.currentUser);
 </script>
 
 <Navigation />

--- a/src/routes/(main)/+layout.ts
+++ b/src/routes/(main)/+layout.ts
@@ -2,6 +2,6 @@ export async function load({ parent }) {
   const { currentUser } = await parent();
 
   return {
-    currentUser
+    currentUser,
   };
-};
+}

--- a/src/routes/(main)/+layout.ts
+++ b/src/routes/(main)/+layout.ts
@@ -1,0 +1,7 @@
+export async function load({ parent }) {
+  const { currentUser } = await parent();
+
+  return {
+    currentUser
+  };
+};

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,17 @@
+import { AUTH_TOKEN_COOKIE_NAME } from '$lib/constants/auth.js';
+import type { User } from '$lib/types/user.js';
+
+export async function load({ cookies }) {
+  const authToken = cookies.get(AUTH_TOKEN_COOKIE_NAME);
+
+  let currentUser: User | null = null;
+
+  if (authToken) {
+    // Pretend to get user
+    currentUser = { username: 'some-user#1234' };
+  }
+
+  return {
+    currentUser
+  };
+};

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,5 +1,5 @@
-import { AUTH_TOKEN_COOKIE_NAME } from '$lib/constants/auth.js';
-import type { User } from '$lib/types/user.js';
+import { AUTH_TOKEN_COOKIE_NAME } from "$lib/constants/auth.js";
+import type { User } from "$lib/types/user.js";
 
 export async function load({ cookies }) {
   const authToken = cookies.get(AUTH_TOKEN_COOKIE_NAME);
@@ -8,10 +8,10 @@ export async function load({ cookies }) {
 
   if (authToken) {
     // Pretend to get user
-    currentUser = { username: 'some-user#1234' };
+    currentUser = { username: "some-user#1234" };
   }
 
   return {
-    currentUser
+    currentUser,
   };
-};
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
-  import type { Snippet } from "svelte";
+  import { type Snippet } from "svelte";
   import "$lib/scss/global.scss";
+  import type { PageData } from "./$types";
 
-  const { children }: { children: Snippet } = $props();
+  const { data, children }: { data: PageData; children: Snippet } = $props();
 </script>
 
-{@render children()}
+{#key data.currentUser}
+  {@render children()}
+{/key}

--- a/src/routes/api/login/+server.ts
+++ b/src/routes/api/login/+server.ts
@@ -14,4 +14,4 @@ export async function GET({ cookies }) {
   cookies.set(AUTH_TOKEN_COOKIE_NAME, "some-token", { path: "/", maxAge: 31536000 });
 
   return new Response(JSON.stringify(currentUser), { headers });
-};
+}

--- a/src/routes/api/login/+server.ts
+++ b/src/routes/api/login/+server.ts
@@ -1,0 +1,17 @@
+import { AUTH_TOKEN_COOKIE_NAME } from "$lib/constants/auth";
+
+export async function GET({ cookies }) {
+  const headers = { "Content-Type": "application/json" };
+
+  // A user would be fetched here first, and a cookie would only be set if the user is set
+
+  const currentUser = { username: "some-user#1234" };
+
+  if (!currentUser) {
+    return new Response(JSON.stringify({ status: "Error" }), { headers, status: 403 });
+  }
+
+  cookies.set(AUTH_TOKEN_COOKIE_NAME, "some-token", { path: "/", maxAge: 31536000 });
+
+  return new Response(JSON.stringify(currentUser), { headers });
+};

--- a/src/routes/api/logout/+server.ts
+++ b/src/routes/api/logout/+server.ts
@@ -6,4 +6,4 @@ export async function GET({ cookies }) {
   cookies.delete(AUTH_TOKEN_COOKIE_NAME, { path: "/" });
 
   return new Response(JSON.stringify(true), { headers });
-};
+}

--- a/src/routes/api/logout/+server.ts
+++ b/src/routes/api/logout/+server.ts
@@ -1,0 +1,9 @@
+import { AUTH_TOKEN_COOKIE_NAME } from "$lib/constants/auth";
+
+export async function GET({ cookies }) {
+  const headers = { "Content-Type": "application/json" };
+
+  cookies.delete(AUTH_TOKEN_COOKIE_NAME, { path: "/" });
+
+  return new Response(JSON.stringify(true), { headers });
+};


### PR DESCRIPTION
## Description

We'll want to keep track of the logged in user somehow, and it needs to work SSR and CSR. We can't store it in a store or a state rune, as these are shared on the server, meaning data could leak from one user to the next. Instead we store an auth token in a cookie. This cookie is used to fetch the user from database. From here the user object is passed via the layout and down to any other load function that might use it. This same object is set via the context api via `setContext`. To make sure this is updated whenever the state on the server changes (eg, the user logs out or in), the main layout is wrapped in a `#key`. Whenever the actual `data.currentUser` object is changed, the whole layout is re-rendered, forcing `setContext` to be run again. This can then be used by any component with `getContext`.

Just like that we have a global user state that works SSR and CSR and isn't shared with the server.

The login and logout are behind an `/api` endpoint. This is mostly to make it easier and more consistent to make calls to the server without directly making calls to the database, the server will do that for us. We make sure the user is updated on the server after calling the endpoints by calling `invalidateAll` after logging in or out.

Of course the actual DB calls aren't included in this PR, so it's all placeholder and made with some assumptions, but hopefully it's a good foundation.

## Screenshots

This doesn't show much, but it shows that the state actually changes when logging in and out. The actual endpoints are called and it isn't just static.

![user-state](https://github.com/user-attachments/assets/d5e07268-c5de-4457-b443-d23731b96f09)
