### PR TITLE
fix: add order to models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,14 +14,13 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-
 model Hero {
   name String @id
   role String
 
   builds StadiumBuild[]
   items  Item[]
-  powers  Power[]
+  powers Power[]
 }
 
 model User {
@@ -52,6 +51,7 @@ model RoundInfo {
   buildId     String
   createdAt   DateTime           @default(now())
   updatedAt   DateTime           @updatedAt
+  orderIndex  Int                @default(0)
   sections    RoundInfoSection[]
   note        String?
 }
@@ -61,6 +61,7 @@ model RoundInfoSection {
   title             String? // When title is missing, that is the standard section for the round
   parentRoundInfo   RoundInfo @relation(fields: [parentRoundInfoId], references: [id])
   parentRoundInfoId String
+  orderIndex        Int       @default(0)
   power             Power?    @relation(fields: [powerId], references: [id])
   powerId           String?
   items             Item[]
@@ -103,6 +104,7 @@ model Stat {
 
 model StatMod {
   id           String  @id @default(cuid(2))
+  orderIndex   Int     @default(0)
   stat         Stat    @relation(fields: [statId], references: [id])
   amount       Int
   isPercentage Boolean @default(false)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -112,9 +112,10 @@ async function main() {
           category: itemCategoryValueToEnum[talent.Category.Value],
           rarity: itemRarityValueToEnum[talent.Rarity.Value],
           statMods: {
-            create: talent.Buffs.map((buff) => {
+            create: talent.Buffs.map((buff, i) => {
               const stat = stats.filter((stat) => stat.name === buff.Name)![0].id;
               return {
+                orderIndex: i,
                 statId: stat,
                 amount: buff.Value < 1 ? buff.Value * 100 : buff.Value,
                 isPercentage: buff.Value < 1,

--- a/src/lib/types/build.ts
+++ b/src/lib/types/build.ts
@@ -14,17 +14,38 @@ export const ItemCategory = {
 } as const;
 export type ItemCategory = (typeof ItemCategory)[keyof typeof ItemCategory];
 
-export const FullStadiumBuildInclude = {
+export const FullRoundInfoSectionInclude: Prisma.RoundInfoSectionInclude = {
+  items: {
+    include: {
+      statMods: {
+        include: {
+          stat: true,
+        },
+        orderBy: {
+          orderIndex: "asc",
+        },
+      },
+    },
+  },
+  power: true,
+} as const;
+
+export const FullRoundInfoInclude: Prisma.RoundInfoInclude = {
+  sections: {
+    include: FullRoundInfoSectionInclude,
+    orderBy: {
+      orderIndex: "asc",
+    },
+  },
+} as const;
+
+export const FullStadiumBuildInclude: Prisma.StadiumBuildInclude = {
   author: true,
   hero: true,
   roundInfos: {
-    include: {
-      sections: {
-        include: {
-          items: true,
-          power: true,
-        },
-      },
+    include: FullRoundInfoInclude,
+    orderBy: {
+      orderIndex: "asc",
     },
   },
 } as const;

--- a/src/lib/utils/faker/build.ts
+++ b/src/lib/utils/faker/build.ts
@@ -65,19 +65,14 @@ export function createRandomRoundInfo(
 
   return {
     note,
+    orderIndex: roundIndex,
     sections: {
       create: Array(faker.number.int({ min: 1, max: 4 }))
         .fill(0)
-        .map((_, i) =>
-          createRandomRoundInfoSection(
-            availableTalents,
-            {
-              includePower: roundIndex % 2 == 0,
-            },
-            {
-              title: i > 0 ? undefined : "",
-            },
-          ),
+        .map((_, sectionIndex) =>
+          createRandomRoundInfoSection(availableTalents, sectionIndex, {
+            includePower: roundIndex % 2 == 0,
+          }),
         ),
     },
   };
@@ -85,6 +80,7 @@ export function createRandomRoundInfo(
 
 export function createRandomRoundInfoSection(
   allTalents: AvailableTalents,
+  sectionIndex: number,
   options: {
     includePower?: boolean;
   } = {},
@@ -93,7 +89,8 @@ export function createRandomRoundInfoSection(
   const { title = faker.word.words({ count: { min: 2, max: 7 } }) } = overwrites;
 
   return {
-    title,
+    title: sectionIndex == 0 ? "" : title,
+    orderIndex: sectionIndex,
     power: options.includePower
       ? {
           connect: { id: faker.helpers.arrayElement(allTalents.powers)!.id },


### PR DESCRIPTION
This PR ensures that models save their order, because Prisma does not do it for us.
