### PR TITLE
fix: include migration for adding ordering

### DIFF
--- a/prisma/migrations/20250430232124_add_ordering/migration.sql
+++ b/prisma/migrations/20250430232124_add_ordering/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "RoundInfo" ADD COLUMN     "orderIndex" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "RoundInfoSection" ADD COLUMN     "orderIndex" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "StatMod" ADD COLUMN     "orderIndex" INTEGER NOT NULL DEFAULT 0;


### PR DESCRIPTION
Forgot to include the migration generated by #31. Oopsie.
