### PR TITLE
feat: Search

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,8 +5,9 @@
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 
 generator client {
-  provider = "prisma-client"
-  output   = "../src/generated/prisma"
+  provider        = "prisma-client"
+  output          = "../src/generated/prisma"
+  previewFeatures = ["fullTextSearchPostgres"]
 }
 
 datasource db {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -128,12 +128,12 @@ async function main() {
   });
 }
 
-main()
-  .then(async () => {
-    await prisma.$disconnect();
-  })
-  .catch(async (e) => {
-    console.error(e);
-    await prisma.$disconnect();
-    process.exit(1);
-  });
+// main()
+//   .then(async () => {
+//     await prisma.$disconnect();
+//   })
+//   .catch(async (e) => {
+//     console.error(e);
+//     await prisma.$disconnect();
+//     process.exit(1);
+//   });

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -128,12 +128,12 @@ async function main() {
   });
 }
 
-// main()
-//   .then(async () => {
-//     await prisma.$disconnect();
-//   })
-//   .catch(async (e) => {
-//     console.error(e);
-//     await prisma.$disconnect();
-//     process.exit(1);
-//   });
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });

--- a/src/lib/components/content/BuildsList.svelte
+++ b/src/lib/components/content/BuildsList.svelte
@@ -46,6 +46,10 @@
       align-items: flex-end;
       justify-content: space-between;
     }
+
+    &:first-child {
+      margin-top: 0;
+    }
   }
 
   .round-selector {

--- a/src/lib/components/content/Search.svelte
+++ b/src/lib/components/content/Search.svelte
@@ -28,6 +28,7 @@
     id="query"
     name="query"
     aria-label="Search"
+    autocomplete="off"
     bind:value={query}
     bind:this={input}
     onkeydown={submit}

--- a/src/lib/components/content/Search.svelte
+++ b/src/lib/components/content/Search.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { afterNavigate, goto } from "$app/navigation";
+  import { page } from "$app/state";
+
+  let query = $state(page.url.searchParams.get("query") || "");
+  let input: HTMLInputElement | null = $state(null);
+
+  afterNavigate(() => {
+    // Keep focus after submiting form
+    if (query && input) input.focus();
+  });
+
+  function submit(event: KeyboardEvent): void {
+    if (event.key !== "Enter") return;
+
+    event.preventDefault();
+
+    if (!query) return;
+
+    goto(`/search?query=${query}`);
+  }
+</script>
+
+<form action="/search" method="GET">
+  <input
+    class="form-input"
+    type="search"
+    id="query"
+    name="query"
+    aria-label="Search"
+    bind:value={query}
+    bind:this={input}
+    onkeydown={submit}
+  />
+</form>

--- a/src/lib/components/layout/Navigation.svelte
+++ b/src/lib/components/layout/Navigation.svelte
@@ -5,6 +5,7 @@
   import { api } from "$lib/utils/api";
   import type { User } from "$src/generated/prisma";
   import { invalidateAll } from "$app/navigation";
+  import Search from "../content/Search.svelte";
 
   const currentUser = getContext("currentUser");
 
@@ -19,6 +20,8 @@
     <a href="/" class="logo">
       <img src={imageLogo} height="64" width="175" alt="OW Armory" />
     </a>
+
+    <Search />
 
     {#if currentUser}
       <UserMenu />

--- a/src/routes/(main)/search/+page.svelte
+++ b/src/routes/(main)/search/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import BuildsList from "$lib/components/content/BuildsList.svelte";
+  import { ROUND_MAX } from "$lib/constants/round";
+  import type { CurrentRound } from "$lib/types/round";
+  import { setContext } from "svelte";
+
+  const { data } = $props();
+
+  const { builds, query } = $derived(data);
+
+  const currentRound: CurrentRound = $state({ value: ROUND_MAX });
+
+  setContext("currentRound", currentRound);
+</script>
+
+<BuildsList header="Search results for &quot;{query}&quot;" {builds} />

--- a/src/routes/(main)/search/+page.ts
+++ b/src/routes/(main)/search/+page.ts
@@ -1,0 +1,13 @@
+import type { FullStadiumBuild as Build } from "$lib/types/build";
+import { api } from "$lib/utils/api.js";
+
+export async function load({ url, fetch }) {
+  const query = url.searchParams.get("query") || "";
+
+  const builds = (await api<Build[]>(`builds/search`, { query }, fetch)) || [];
+
+  return {
+    builds,
+    query,
+  };
+}

--- a/src/routes/api/builds/search/+server.ts
+++ b/src/routes/api/builds/search/+server.ts
@@ -1,0 +1,35 @@
+import { prisma } from "$src/database/prismaClient.server.js";
+import { FullStadiumBuildInclude } from "$src/lib/types/build";
+
+export async function GET({ url }) {
+  const headers = { "Content-Type": "application/json" };
+
+  const query = url.searchParams.get("query") || "";
+
+  // Require all words to be present in results
+  const search = query.split(/\s+/g).join(" & ");
+
+  const PAGE_SIZE = 20;
+
+  const builds = await prisma.stadiumBuild.findMany({
+    where: {
+      buildTitle: {
+        search,
+      },
+      heroName: {
+        search,
+      },
+    },
+    orderBy: {
+      _relevance: {
+        fields: ["buildTitle", "heroName"],
+        search,
+        sort: "desc",
+      },
+    },
+    include: FullStadiumBuildInclude,
+    take: PAGE_SIZE,
+  });
+
+  return new Response(JSON.stringify(builds), { headers });
+}


### PR DESCRIPTION
## Description

This PR adds search via full-text search from Prisma. Search results are search for on either the hero name or the build title. The query is inclusive(?) in that results require all words to be present. If you search "Cool build", both "Cool" and "build" need to be present in the title. 

The search form itself is placed in the main navigation, but it is unstyled. The styles it would rely on are in #29, and I didn't want to extend that chain any more.
The form is not showing results as you type, instead only showing results when you press enter. This is done through a simple navigate, where the query param is used in the server endpoints.

## Screenshots

![search](https://github.com/user-attachments/assets/e769fb07-6314-449e-9b20-add63d1bf750)