### PR TITLE
chore: Remove popular builds section

### DIFF
--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -55,8 +55,6 @@
 
 <Heroes />
 
-<BuildsList header="Popular Builds" builds={(latestBuilds || [])?.slice(0, 3)} />
-
 <BuildsList header="Latest Builds" builds={latestBuilds} />
 
 {#if latestBuilds}


### PR DESCRIPTION
## Description

We're not tracking popularity at the moment, so the section is useless.

## Screenshots

![image](https://github.com/user-attachments/assets/e5c82f14-add5-413e-9dee-3f6a6ec81d91)
