### PR TITLE
style: Disable wrapping on buttons

### DIFF
--- a/src/lib/scss/elements/_buttons.scss
+++ b/src/lib/scss/elements/_buttons.scss
@@ -18,6 +18,7 @@ button {
   text-decoration: none;
   font-family: $font-stack-brand;
   font-size: $font-size-base;
+  white-space: nowrap;
 
   &:not([disabled]):not(.disabled):hover,
   &:not([disabled]):not(.disabled):active,


### PR DESCRIPTION
## Description

Wrapping is hardly ever wanted in buttons, in this case it messed with the sign in button in the navigation

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/9318ee8a-f009-466f-8ae3-ea71eb8dba2d) | ![image](https://github.com/user-attachments/assets/11b28b4e-22b9-4a60-bfd5-6ec9cd8275a4)
