### PR TITLE
feat: Add Create build button to navigation

### DIFF
--- a/src/lib/components/auth/SignInButton.svelte
+++ b/src/lib/components/auth/SignInButton.svelte
@@ -1,5 +1,13 @@
-<script>
+<script lang="ts">
   import { SignIn } from "@auth/sveltekit/components";
+  import type { Snippet } from "svelte";
+
+  interface Props {
+    secondary?: boolean;
+    children?: Snippet;
+  }
+
+  const { secondary = false, children }: Props = $props();
 
   let loading = $state(false);
 </script>
@@ -9,9 +17,16 @@
     <!-- The wrapper already is a button, we can't have a button in a button -->
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
-    <div class="button" class:disabled={loading} onclick={() => (loading = true)}>
+    <div
+      class="button"
+      class:button--secondary={secondary}
+      class:disabled={loading}
+      onclick={() => (loading = true)}
+    >
       {#if loading}
         Signing in...
+      {:else if children}
+        {@render children()}
       {:else}
         Sign in with Battle.net
       {/if}

--- a/src/lib/components/content/CreateBuildButton.svelte
+++ b/src/lib/components/content/CreateBuildButton.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { getContext } from "svelte";
+  import SignInButton from "../auth/SignInButton.svelte";
+
+  const currentUser = getContext("currentUser");
+</script>
+
+{#if currentUser}
+  <a href="/build/new" class="button">Create build</a>
+{:else}
+  <SignInButton>Create build</SignInButton>
+{/if}

--- a/src/lib/components/layout/Navigation.svelte
+++ b/src/lib/components/layout/Navigation.svelte
@@ -4,6 +4,7 @@
   import { getContext } from "svelte";
   import SignInButton from "$lib/components/auth/SignInButton.svelte";
   import Search from "$src/lib/components/layout/Search.svelte";
+  import CreateBuildButton from "../content/CreateBuildButton.svelte";
 
   const currentUser = getContext("currentUser");
 </script>
@@ -16,11 +17,15 @@
 
     <Search />
 
-    {#if currentUser}
-      <UserMenu />
-    {:else}
-      <SignInButton />
-    {/if}
+    <div class="actions">
+      {#if currentUser}
+        <UserMenu />
+      {:else}
+        <SignInButton secondary />
+      {/if}
+
+      <CreateBuildButton />
+    </div>
   </div>
 </nav>
 
@@ -70,5 +75,11 @@
     img {
       display: block;
     }
+  }
+
+  .actions {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
   }
 </style>

--- a/src/lib/scss/elements/_buttons.scss
+++ b/src/lib/scss/elements/_buttons.scss
@@ -18,6 +18,7 @@ button {
   text-decoration: none;
   font-family: $font-stack-brand;
   font-size: $font-size-base;
+  white-space: nowrap;
 
   &:not([disabled]):not(.disabled):hover,
   &:not([disabled]):not(.disabled):active,


### PR DESCRIPTION
## Description

Merges into #45 

This adds a button to the navigation to create a new build. When logged out this button functions as a sign in button, when logged in it's a link to the build form.

## Screenshots

Logged out
![image](https://github.com/user-attachments/assets/123fd456-c59d-47bd-ba4a-87b4300beeac)

Logged in
![image](https://github.com/user-attachments/assets/a091ff78-2ae0-4a1f-be89-db84677390dd)

