### PR TITLE
fix: ensure rarity classes are properly applied

### DIFF
--- a/src/lib/components/content/Item.svelte
+++ b/src/lib/components/content/Item.svelte
@@ -31,7 +31,7 @@
   </Card>
 {:else}
   <Popover onclick={() => onclick(item)}>
-    <div class="item {rarity}" class:large class:sold>
+    <div class="item {rarity.toLowerCase()}" class:large class:sold>
       <img src={iconURL} alt={name} />
     </div>
 


### PR DESCRIPTION
Small and simple: since rarity classes are capitalized but we expect them to be lowercase, we need to convert the rarity for the CSS