### PR TITLE
style: Fix several styling inconsistencies in power and item grids

### DIFF
--- a/src/lib/components/common/Card.svelte
+++ b/src/lib/components/common/Card.svelte
@@ -28,6 +28,7 @@
     position: relative;
     display: grid;
     grid-template-rows: 3.5rem auto;
+    height: 100%;
     border-radius: $border-radius;
     background: $color-border;
     box-shadow: inset 0 0 1px $color-text-alt;
@@ -66,7 +67,7 @@
     gap: 1rem;
     font-family: $font-stack-brand;
     color: $white;
-    font-size: 115%;
+    line-height: 1;
   }
 
   .content {

--- a/src/lib/components/content/SharedDetail.svelte
+++ b/src/lib/components/content/SharedDetail.svelte
@@ -49,6 +49,8 @@
     margin: 0;
     padding: 0 0 0.5rem;
     color: $color-text-alt;
+    font-size: $font-size-small;
+    line-height: 1.5;
   }
 
   .cost {

--- a/src/lib/components/form/ItemsGrid.svelte
+++ b/src/lib/components/form/ItemsGrid.svelte
@@ -81,7 +81,7 @@
   .row {
     padding: 1rem;
     border-radius: $border-radius;
-    background: $color-bg-dark;
+    background: color.adjust($color-bg-dark, $lightness: 1%);
     border: 2px solid var(--color-rarity);
 
     @each $rarity, $color in $color-rarities {
@@ -108,6 +108,10 @@
   .item {
     border-radius: 50%;
     outline-offset: 0.25rem;
+
+    &:hover {
+      outline: 2px solid $secondary;
+    }
 
     .owned & {
       &:hover {

--- a/src/lib/components/form/PowersGrid.svelte
+++ b/src/lib/components/form/PowersGrid.svelte
@@ -26,7 +26,7 @@
       {@const highlighted = currentlySelected?.id === power.id}
 
       <div class="power" class:owned class:highlighted>
-        <Power {power} {onclick} large />
+        <Power {power} {onclick} full />
       </div>
     {/each}
   </div>
@@ -44,7 +44,7 @@
   .block {
     padding: 1rem;
     border-radius: $border-radius;
-    background: $color-bg-dark;
+    background: color.adjust($color-bg-dark, $lightness: 1%);
     border: 2px solid $primary;
   }
 
@@ -59,6 +59,12 @@
     position: relative;
     border-radius: $border-radius-small;
     outline-offset: 0.25rem;
+    height: 100%;
+    cursor: pointer;
+
+    &:hover {
+      outline: 2px solid $secondary;
+    }
 
     &.owned {
       filter: saturate(0);

--- a/src/lib/scss/global.scss
+++ b/src/lib/scss/global.scss
@@ -23,6 +23,7 @@ body {
   line-height: 1.5;
 
   @include breakpoint(tablet) {
+    line-height: 1.35;
     font-size: $font-size-base;
   }
 


### PR DESCRIPTION
## Description

- Powers didn't use the full variant in powers grid
- Cards didn't fill the full height in the powers grid
- Added missing hover for items and powers in grid
- Adjust spacing and font sizes

Before | Before with full cards | After
--- | --- | ---
![image](https://github.com/user-attachments/assets/b29f5b18-1af6-433f-b23c-485a3bff7be8) | ![image](https://github.com/user-attachments/assets/630a82dd-fc64-4494-aeee-389d07e29116) | ![image](https://github.com/user-attachments/assets/9e64ac49-8d28-451d-ba00-ff9e95f07fec)
