### PR TITLE
fix: Fill out entire icon circle in items

### DIFF
--- a/src/lib/components/content/Item.svelte
+++ b/src/lib/components/content/Item.svelte
@@ -45,6 +45,7 @@
   @use "sass:color";
 
   .item {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -52,18 +53,28 @@
     width: $item-size;
     height: $item-size;
     overflow: hidden;
-    padding: 0.25rem;
     border: 2px solid var(--color-rarity);
-    box-shadow: inset 0 0 0 1px $color-bg-base;
     background: var(--color-rarity);
+
+    &:hover {
+      filter: brightness(1.2);
+    }
+
+    &::before {
+      content: "";
+      display: block;
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      border-radius: 50%;
+      border: 2px solid $color-bg-base;
+    }
 
     @each $rarity, $color in $color-rarities {
       &.#{$rarity} {
         --color-rarity: #{$color};
-
-        &:hover {
-          --color-rarity: #{color.adjust($color, $lightness: 10%)};
-        }
       }
     }
 


### PR DESCRIPTION
## Description

When first creating the items I assumed the icons would be PNGs, they are not. Turns out that's good, because hero specific icons don't have consistent background colors.

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/6a9103cb-7dfd-40e8-9929-c25f325c1108) | ![image](https://github.com/user-attachments/assets/d9b94811-a676-4cce-bfd5-d9debe6fc93b)
![image](https://github.com/user-attachments/assets/66774a8d-1ee3-4c59-b247-d72c6cd1705e) | ![image](https://github.com/user-attachments/assets/e3147293-ac6b-4635-aa78-7f9ede87cde0)

