### PR TITLE
fix: Use lowercase rarity in grid

### DIFF
--- a/src/lib/components/form/ItemsGrid.svelte
+++ b/src/lib/components/form/ItemsGrid.svelte
@@ -25,8 +25,8 @@
   {#each itemRarities as rarity (rarity)}
     {@const items = availableItems.filter((item) => item.rarity === rarity)}
 
-    <div class="row {rarity}">
-      <h3>{rarity}</h3>
+    <div class="row {rarity.toLowerCase()}">
+      <h3>{rarity.toLowerCase()}</h3>
 
       <div class="items">
         {#each items as item (item.id)}


### PR DESCRIPTION
## Description

Similar to #47, but in the form grids instead

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/99f195e3-ce13-449e-859f-cc600c280f31) | ![image](https://github.com/user-attachments/assets/fb4818c6-f49e-4bd5-a7fc-f355bcc4fceb)
