### PR TITLE
fix: Sort items in itemsGrid by cost and hero specific-ness

### DIFF
--- a/src/lib/components/form/ItemsGrid.svelte
+++ b/src/lib/components/form/ItemsGrid.svelte
@@ -19,11 +19,21 @@
   }: Props = $props();
 
   const itemRarities = Object.values(ItemRarity);
+
+  function sortItems(a: ItemType, b: ItemType): number {
+    // Hero specific items always come after general items
+    if (a.heroName !== b.heroName) {
+      return a.heroName ? 1 : -1;
+    }
+
+    // Sort by cost
+    return a.cost - b.cost;
+  }
 </script>
 
 <div class="rows">
   {#each itemRarities as rarity (rarity)}
-    {@const items = availableItems.filter((item) => item.rarity === rarity)}
+    {@const items = availableItems.filter((item) => item.rarity === rarity).sort(sortItems)}
 
     <div class="row {rarity}">
       <h3>{rarity}</h3>


### PR DESCRIPTION
## Description

To match the sorting in-game, the items are sorted first by whether or not they are hero specific, and after by cost.

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/9f27fd5b-4592-4629-9474-81cac3b693e4) | ![image](https://github.com/user-attachments/assets/fdab64c5-2873-4ade-9e6b-8cc611e94263)
