### PR TITLE
style: Simplify tabs in build form

### DIFF
--- a/src/lib/components/form/BuildForm.svelte
+++ b/src/lib/components/form/BuildForm.svelte
@@ -268,7 +268,7 @@
       {/if}
     </div>
 
-    <div class="tabs-content dark">
+    <div class="tabs-content dark inset">
       {#if currentTalentTypeTab === powerTalentType}
         <PowersGrid
           {availablePowers}
@@ -287,7 +287,7 @@
       {/if}
     </div>
 
-    <div class="form-group">
+    <div class="form-group inset">
       <label class="form-label" for="round-notes">Round notes</label>
       <p class="form-help" id="round-notes">
         Provide an optional short description on the current round, explaining options,
@@ -348,6 +348,7 @@
 
     &.dark {
       background: $color-bg-dark;
+      border-radius: 0;
     }
   }
 
@@ -369,14 +370,19 @@
   }
 
   .tabs-content {
-    padding: 1.5rem;
     margin-bottom: 3rem;
     border: 1px solid $color-border;
     border-radius: 0 0 $border-radius $border-radius;
 
     &.dark {
-      border-color: $color-bg-dark;
+      border: 0;
+      border-radius: 0;
+      margin: 0;
     }
+  }
+
+  .inset {
+    padding: 1.5rem;
   }
 
   .order {


### PR DESCRIPTION
## Description

To make a little more space and make the build form feel a bit cleaner, this PR removes one inset in tabs. Basically removing one depth of paddings. Easier explained in screenshots!

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/26e2f674-63aa-4166-83ee-e1e58ecd00c7) | ![image](https://github.com/user-attachments/assets/609fecf5-bc44-47ff-88c1-1294692ea181)
