### PR TITLE
style: Mark bracketed strings in talent descriptions

### DIFF
--- a/src/lib/components/content/SharedDetail.svelte
+++ b/src/lib/components/content/SharedDetail.svelte
@@ -6,6 +6,10 @@
   }
 
   const { name, description, cost = 0 }: Props = $props();
+
+  function wrapBracketsWithMark(text: string): string {
+    return text.replace(/\[[^\]]+\]/g, (match) => `<mark>${match}</mark>`);
+  }
 </script>
 
 <div class="detail">
@@ -14,7 +18,8 @@
   {/if}
 
   {#if description}
-    <p class="description">{description}</p>
+    <!-- eslint-disable-next-line svelte/no-at-html-tags This should be safe, right? The input is determined by us. -->
+    <p class="description">{@html wrapBracketsWithMark(description)}</p>
   {/if}
 
   <div class="cost">
@@ -51,6 +56,11 @@
     color: $color-text-alt;
     font-size: $font-size-small;
     line-height: 1.5;
+
+    :global(mark) {
+      background: transparent;
+      color: $white;
+    }
   }
 
   .cost {


### PR DESCRIPTION
Makes the text feel that much more readable.

## Description

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/9cc4adc6-c405-4b0a-8f39-bb0b65178ca9) | ![image](https://github.com/user-attachments/assets/1b14e0fa-82f5-44fc-a2cf-d46df365b461)
![image](https://github.com/user-attachments/assets/849af0af-2a55-40e9-8f04-36f9e716b1b4) | ![image](https://github.com/user-attachments/assets/da1624e7-2895-4790-8ee7-252f2b39e65a)
