### PR TITLE
feat: Use currency icon instead of dollar sign for item cost

### DIFF
--- a/src/lib/components/content/SharedDetail.svelte
+++ b/src/lib/components/content/SharedDetail.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import iconCurrency from "$lib/images/icons/currency.svg";
+
   interface Props {
     name?: string;
     description?: string | null;
@@ -19,7 +21,8 @@
 
   <div class="cost">
     {#if cost}
-      ${cost.toLocaleString()}
+      <img src={iconCurrency} alt="$" height="18" width="22" />
+      {cost.toLocaleString()}
     {:else}
       <strong>Power</strong>
     {/if}
@@ -54,6 +57,9 @@
   }
 
   .cost {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     padding-top: 0.5rem;
     margin-top: auto;
     border-top: 1px solid rgba($color-text-alt, 0.35);

--- a/src/lib/components/content/SharedDetail.svelte
+++ b/src/lib/components/content/SharedDetail.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import iconCurrency from "$lib/images/icons/currency.svg";
+  import CurrencyIcon from "$lib/components/icon/CurrencyIcon.svelte";
 
   interface Props {
     name?: string;
@@ -21,7 +21,7 @@
 
   <div class="cost">
     {#if cost}
-      <img src={iconCurrency} alt="$" height="18" width="22" />
+      <CurrencyIcon />
       {cost.toLocaleString()}
     {:else}
       <strong>Power</strong>

--- a/src/lib/components/form/ItemsGrid.svelte
+++ b/src/lib/components/form/ItemsGrid.svelte
@@ -2,6 +2,7 @@
   import Item from "../content/Item.svelte";
   import type { Item as ItemType } from "$src/generated/prisma";
   import { ItemRarity } from "$src/lib/types/build";
+  import iconCurrency from "$lib/images/icons/currency.svg";
 
   interface Props {
     availableItems: ItemType[];
@@ -59,7 +60,8 @@
               {:else if buying}
                 Purchased
               {:else}
-                ${item.cost.toLocaleString()}
+                <img src={iconCurrency} alt="$" height="16" width="20" />
+                {item.cost.toLocaleString()}
               {/if}
             </div>
 
@@ -144,6 +146,9 @@
   }
 
   .cost {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
     color: $white;
     font-family: $font-stack-brand;
     font-size: $font-size-small;

--- a/src/lib/components/icon/CurrencyIcon.svelte
+++ b/src/lib/components/icon/CurrencyIcon.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import iconCurrency from "$lib/images/icons/currency.svg";
+
+  interface Props {
+    scale?: number;
+  }
+
+  const { scale = 1 }: Props = $props();
+</script>
+
+<img class="icon" src={iconCurrency} alt="$" height={18 * scale} width={22 * scale} />
+
+<style lang="scss">
+  .icon {
+    display: inline-block;
+  }
+</style>

--- a/src/lib/images/icons/currency.svg
+++ b/src/lib/images/icons/currency.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="116" height="94" viewBox="0 0 116 94">
+  <path fill="#fff" d="M104,33L75,84,65,94H80l36-64L86,0H78L71,9H82Z"/>
+  <path fill="#fff" d="M12,33L41,84,51,94H36L0,30,30,0h8l7,9H34Z"/>
+  <path fill="#fff" d="M59,24H42L31,34,51,74H66L86,34,76,24H59Z"/>
+</svg>

--- a/src/routes/(main)/build/[id]-[slug]/+page.svelte
+++ b/src/routes/(main)/build/[id]-[slug]/+page.svelte
@@ -16,6 +16,7 @@
   import type { FullStadiumBuild } from "$src/lib/types/build";
   import snarkdown from "snarkdown";
   import DOMPurify from "isomorphic-dompurify";
+  import CurrencyIcon from "$src/lib/components/icon/CurrencyIcon.svelte";
 
   const currentRound: CurrentRound = $state({ value: ROUND_MAX });
 
@@ -60,7 +61,9 @@
       <CompoundedBuild {build} />
 
       <h2 class="build-cost">
-        Build cost: {getBuildCostForRound(build, currentRound.value).toLocaleString()}
+        Build cost:<br />
+        <CurrencyIcon scale={1.5} />
+        {getBuildCostForRound(build, currentRound.value).toLocaleString()}
       </h2>
 
       <DashedHeader text="Stats" />


### PR DESCRIPTION
## Description
I traced the icon manually and it's not perfect :|. I couldn't find it in the datatool vector images, but hey, it's close.

## Screenshots
![image](https://github.com/user-attachments/assets/880dfaea-eb29-4c30-b9c4-0eb2be68fded)
