### PR TITLE
fix: Incorrect merge

### DIFF
--- a/src/lib/components/content/RoundInfo.svelte
+++ b/src/lib/components/content/RoundInfo.svelte
@@ -24,15 +24,13 @@
           <Power {power} full outline />
         {/if}
 
-        <div class="section__items">
-          {#each soldItems as item (item.id)}
-            <Item {item} sold />
-          {/each}
+        {#each soldItems as item (item.id)}
+          <Item {item} sold full />
+        {/each}
 
-          {#each purchasedItems as item (item.id)}
-            <Item {item} />
-          {/each}
-        </div>
+        {#each purchasedItems as item (item.id)}
+          <Item {item} full />
+        {/each}
       </div>
     {/each}
   </div>


### PR DESCRIPTION
## Description

Items were supposed to be using their full variant, and the parent element was removed

## Screenshots

![image](https://github.com/user-attachments/assets/f27d385a-155b-468b-83cf-e520f3baf6e8)
