### PR TITLE
style: Use more consistent border for power icons

### DIFF
--- a/src/lib/components/content/Power.svelte
+++ b/src/lib/components/content/Power.svelte
@@ -67,12 +67,16 @@
       height: $power-size-large;
       border-radius: $border-radius;
     }
+  }
 
-    img {
-      width: 100%;
-      height: auto;
-      border-radius: $border-radius-small;
-      border: 1px solid $color-bg-base;
+  img {
+    width: 100%;
+    height: auto;
+    border-radius: $border-radius-small;
+    border: 2px solid $color-bg-base;
+
+    .large & {
+      border-radius: $border-radius;
     }
   }
 </style>


### PR DESCRIPTION
The border for items was adjusted, for powers they were still a little different. Additionally, the border radius wasn't correct for large icons

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/19060de1-146d-46c9-b2be-9bf5d5b0ebd7) | ![image](https://github.com/user-attachments/assets/e30e2ee5-2774-4778-a7da-895cf837e2c9)
![image](https://github.com/user-attachments/assets/8b41d1c2-ebb8-431f-b335-c811510842f1) | ![image](https://github.com/user-attachments/assets/4241886a-7e2d-4695-ba00-3714f7566287)
