### PR TITLE
style: Add backdrops to purchase orders

### DIFF
--- a/src/lib/components/content/BuildItemOrder.svelte
+++ b/src/lib/components/content/BuildItemOrder.svelte
@@ -50,6 +50,9 @@
     align-items: center;
     flex-wrap: wrap;
     gap: 0.25rem;
+    padding: 0.75rem;
+    border-radius: $border-radius-small;
+    background: $color-bg-dark;
   }
 
   .cell {

--- a/src/lib/components/content/BuildPowersOrder.svelte
+++ b/src/lib/components/content/BuildPowersOrder.svelte
@@ -45,6 +45,9 @@
     align-items: center;
     flex-wrap: wrap;
     gap: 0.25rem;
+    padding: 0.75rem;
+    border-radius: $border-radius-small;
+    background: $color-bg-dark;
   }
 
   .missing-power {


### PR DESCRIPTION
## Description

Just to make them stand out a little more, and have them fit in a little better.

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/9bd28a0c-5cd7-452e-bcfc-44ff19221ca2)  | ![image](https://github.com/user-attachments/assets/d6ccaef4-d9c1-4dd6-8457-145b127e1717)
![image](https://github.com/user-attachments/assets/09e7265a-5e22-498b-a239-bd4b2e4d2a7a) |![image](https://github.com/user-attachments/assets/6f199ea4-cf53-4bc0-bbd5-9cbc06e0652c)

