### PR TITLE
style: Use slightly lighter color for secondary variable

### DIFF
--- a/src/lib/scss/_variables.scss
+++ b/src/lib/scss/_variables.scss
@@ -1,7 +1,7 @@
 @use "$lib/scss/_functions.scss" as *;
 
 $primary: #ee6a1d;
-$secondary: #127da1;
+$secondary: #1592bc;
 
 $white: #fff;
 $black: #000;


### PR DESCRIPTION
## Description

This color is used primarily for text, for this purpose it was just slightly out of proper contrast ratios. This change makes that color just a little lighter, pushing it a 4.5 contrast ratio, it was 3.5 before.

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/8fcfceec-2f81-42c6-8578-b349846f9ad3) | ![image](https://github.com/user-attachments/assets/90a0d8be-297b-40aa-a6a9-7213e651c245)
