### PR TITLE
feat: Add full items and powers pages

### DIFF
--- a/src/routes/(main)/items/+page.svelte
+++ b/src/routes/(main)/items/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import type { Item as ItemType } from "$src/generated/prisma/client.js";
+  import Item from "$src/lib/components/content/Item.svelte";
+
+  const { data } = $props();
+  const { items } = $derived(data);
+
+  // ChatGPT special; group items by hero and sort to put null first
+  const groups = $derived.by(() => {
+    const groups = new Map<string | null, ItemType[]>();
+
+    for (const item of items) {
+      const key = item.heroName ?? null;
+      if (!groups.has(key)) groups.set(key, []);
+
+      groups.get(key)?.push(item);
+    }
+
+    // Sort to put null first
+    const sortedGroups = [...groups.entries()].sort(([a], [b]) => {
+      if (a === null) return -1;
+      if (b === null) return 1;
+      return a.localeCompare(b);
+    });
+
+    return sortedGroups;
+  });
+</script>
+
+<h1>All items</h1>
+
+{#each groups as [heroName, items] (heroName)}
+  <h2>{heroName || "General"}</h2>
+
+  <div class="grid">
+    {#each items as item (item.id)}
+      <Item {item} full />
+    {/each}
+  </div>
+{/each}
+
+<style lang="scss">
+  h1 {
+    margin-top: 0;
+  }
+
+  h2 {
+    margin-top: $vertical-offset-large;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 1rem;
+  }
+</style>

--- a/src/routes/(main)/items/+page.ts
+++ b/src/routes/(main)/items/+page.ts
@@ -1,0 +1,10 @@
+import { api } from "$lib/utils/api.js";
+import type { Item } from "$src/generated/prisma/client.js";
+
+export async function load({ fetch }) {
+  const items = (await api<Item[]>(`/talents/items`, {}, fetch)) || [];
+
+  return {
+    items,
+  };
+}

--- a/src/routes/(main)/powers/+page.svelte
+++ b/src/routes/(main)/powers/+page.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import type { Power as PowerType } from "$src/generated/prisma/client.js";
+  import Power from "$src/lib/components/content/Power.svelte";
+
+  const { data } = $props();
+  const { powers } = $derived(data);
+
+  // ChatGPT special; group powers by hero and sort to put null first
+  const groups = $derived.by(() => {
+    const groups = new Map<string, PowerType[]>();
+
+    for (const power of powers) {
+      const key = power.heroName;
+      if (!groups.has(key)) groups.set(key, []);
+
+      groups.get(key)?.push(power);
+    }
+
+    // Sort to put null first
+    const sortedGroups = [...groups.entries()].sort(([a], [b]) => {
+      if (a === null) return -1;
+      if (b === null) return 1;
+      return a.localeCompare(b);
+    });
+
+    return sortedGroups;
+  });
+</script>
+
+<h1>All powers</h1>
+
+{#each groups as [heroName, powers] (heroName)}
+  <h2>{heroName}</h2>
+
+  <div class="grid">
+    {#each powers as power (power.id)}
+      <Power {power} full />
+    {/each}
+  </div>
+{/each}
+
+<style lang="scss">
+  h1 {
+    margin-top: 0;
+  }
+
+  h2 {
+    margin-top: $vertical-offset-large;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 1rem;
+  }
+</style>

--- a/src/routes/(main)/powers/+page.ts
+++ b/src/routes/(main)/powers/+page.ts
@@ -1,0 +1,10 @@
+import { api } from "$lib/utils/api.js";
+import type { Power } from "$src/generated/prisma/client.js";
+
+export async function load({ fetch }) {
+  const powers = (await api<Power[]>(`/talents/powers`, {}, fetch)) || [];
+
+  return {
+    powers,
+  };
+}


### PR DESCRIPTION
To help us debug and find incorrect powers/items, this PR adds a powers and items page that simply lists all powers or items, grouped by hero.

This isn't really meant to be a public page, so it's super basic and not all that well made. Maybe one day these could be public facing, with a little search bar too, that'd be neat.

## Screenshots

Powers | Items
--- | ---
![image](https://github.com/user-attachments/assets/6f387275-3c38-4ae6-860c-f4428ee5826f) | ![image](https://github.com/user-attachments/assets/d0810ae0-c34e-4779-a95b-0255da406b19)
