### PR TITLE
feat: Add search to items and powers grid

### DIFF
--- a/src/lib/components/form/BuildForm.svelte
+++ b/src/lib/components/form/BuildForm.svelte
@@ -44,6 +44,7 @@
   let heroName: HeroName | null = $state(build.heroName as HeroName);
   let errorMessage = $state("");
   let saving = $state(false);
+  let query = $state("");
 
   const selectedHero = $derived(heroFromHeroName(heroName as HeroName));
 
@@ -55,6 +56,9 @@
   const availablePowers = $derived(
     availableTalents.powers.filter((power) => power.heroName == heroName),
   );
+
+  const filteredItems = $derived(availableItems.filter(filterTalents));
+  const filteredPowers = $derived(availablePowers.filter(filterTalents));
 
   const futureRounds: FlatFullRoundInfo[] = $derived(
     build.roundInfos!.slice(currentRoundIndex + 1, ROUND_MAX),
@@ -183,6 +187,12 @@
       saving = false;
     }
   }
+
+  function filterTalents(talent: Item[] | Power[]): boolean {
+    // Filter on the full object by stringifying it. Bit ugly, but that makes it easy to filter by name,
+    // description, and stat names all at once.
+    return JSON.stringify(talent).toLowerCase().includes(query.toLowerCase());
+  }
 </script>
 
 {#if errorMessage}
@@ -268,12 +278,22 @@
       {/if}
     </div>
 
+    <div class="inset">
+      <input
+        type="text"
+        class="form-input"
+        placeholder="Search powers and items..."
+        bind:value={query}
+      />
+    </div>
+
     <div class="tabs-content dark inset">
       {#if currentTalentTypeTab === powerTalentType}
         <PowersGrid
           {availablePowers}
           currentlySelected={currentRoundSection.power}
           previouslySelected={powersFromPreviousRounds}
+          filtered={filteredPowers}
           onclick={selectPower}
         />
       {:else}
@@ -283,6 +303,7 @@
           currentlyPurchasing={currentRoundSection.purchasedItems}
           currentlySelling={currentRoundSection.soldItems}
           previouslySelected={itemsFromPreviousRounds}
+          filtered={filteredItems}
         />
       {/if}
     </div>
@@ -383,6 +404,10 @@
 
   .inset {
     padding: 1.5rem;
+
+    + .inset {
+      padding-top: 0;
+    }
   }
 
   .order {

--- a/src/lib/components/form/ItemsGrid.svelte
+++ b/src/lib/components/form/ItemsGrid.svelte
@@ -9,6 +9,7 @@
     currentlyPurchasing: ItemType[];
     currentlySelling: ItemType[];
     previouslySelected: ItemType[];
+    filtered: ItemType[];
     onclick: (item: ItemType) => void;
   }
   const {
@@ -16,6 +17,7 @@
     currentlyPurchasing = [],
     currentlySelling = [],
     previouslySelected = [],
+    filtered = [],
     onclick = () => null,
   }: Props = $props();
 
@@ -44,8 +46,9 @@
           {@const owned = previouslySelected.some((i) => i.id === item.id)}
           {@const buying = currentlyPurchasing.some((i) => i.id === item.id)}
           {@const selling = currentlySelling.some((i) => i.id == item.id)}
+          {@const faded = !filtered.some((i) => i.id == item.id)}
 
-          <div class="cell" class:active={buying || selling} class:owned>
+          <div class="cell" class:active={buying || selling} class:owned class:faded>
             <div class="item">
               <Item {item} {onclick} large />
             </div>
@@ -143,6 +146,12 @@
         outline: 2px solid $primary;
       }
     }
+
+    .faded & {
+      :global(.item) {
+        opacity: 0.25;
+      }
+    }
   }
 
   .cost {
@@ -159,6 +168,10 @@
 
     .active & {
       color: $primary;
+    }
+
+    .faded & {
+      opacity: 0.25;
     }
   }
 

--- a/src/lib/components/form/PowersGrid.svelte
+++ b/src/lib/components/form/PowersGrid.svelte
@@ -6,6 +6,7 @@
     availablePowers: PowerType[];
     currentlySelected: PowerType | null;
     previouslySelected: PowerType[];
+    filtered: PowerType[];
     onclick: (item: PowerType) => void;
   }
 
@@ -13,6 +14,7 @@
     availablePowers = [],
     currentlySelected = null,
     previouslySelected = [],
+    filtered = [],
     onclick = () => null,
   }: Props = $props();
 </script>
@@ -24,8 +26,9 @@
     {#each availablePowers as power (power.id)}
       {@const owned = previouslySelected.some((i) => i.id === power.id)}
       {@const highlighted = currentlySelected?.id === power.id}
+      {@const faded = !filtered.some((i) => i.id == power.id)}
 
-      <div class="power" class:owned class:highlighted>
+      <div class="power" class:owned class:highlighted class:faded>
         <Power {power} {onclick} full />
       </div>
     {/each}
@@ -73,6 +76,10 @@
 
     &.highlighted {
       outline: 2px solid $primary;
+    }
+
+    &.faded {
+      opacity: 0.25;
     }
   }
 </style>


### PR DESCRIPTION
## Description

To make finding the right item just that little bit easier, you can now search! Search works by searching on the entire item or power object, stringified. Super simple and dumb, but it also works just fine.

## Screenshots

Please ignore the gif crapping itself

![search-items](https://github.com/user-attachments/assets/0772a01e-6da0-43e2-90d3-582302dc43de)
