### PR TITLE
fix: Additionally sort items by name

### DIFF
--- a/src/lib/components/form/ItemsGrid.svelte
+++ b/src/lib/components/form/ItemsGrid.svelte
@@ -28,7 +28,12 @@
     }
 
     // Sort by cost
-    return a.cost - b.cost;
+    if (a.cost !== b.cost) {
+      return a.cost - b.cost;
+    }
+
+    // Lastly, sort by name
+    return a.name.localeCompare(b.name);
   }
 </script>
 


### PR DESCRIPTION
## Description

All general items are sorted by cost and then by name. For hero specific items that's less so the case, _most_ items seem to be sorted by name, but not all. So even this sorting isn't quite right, but it is one step closer. The only proper sorting seems to be to do it manually, which I'm not sure is worth the extra effort. Largely because hero specific items aren't exactly plentyful anyway.