### PR TITLE
fix: Include description in post

### DIFF
--- a/src/routes/api/build/form/+server.ts
+++ b/src/routes/api/build/form/+server.ts
@@ -38,10 +38,8 @@ export async function POST({ locals, request }) {
   try {
     newBuild = await prisma.stadiumBuild.create({
       data: {
-        buildTitle: validatedBuild.buildTitle,
+        ...validatedBuild,
         authorId: currentUser.id,
-        heroName: validatedBuild.heroName,
-        additionalNotes: validatedBuild.additionalNotes,
         roundInfos: {
           create: validatedBuild.roundInfos.map(
             (roundInfo, i): Prisma.RoundInfoCreateWithoutParentBuildInput => ({


### PR DESCRIPTION
The description was not included when posting a title, always leaving it empty. I could have included just the description, but is there any reason not to just spread validatedBuild?