### PR TITLE
feat: Add front-end inline validations

### DIFF
--- a/src/lib/actions/validateLength.ts
+++ b/src/lib/actions/validateLength.ts
@@ -1,0 +1,75 @@
+import type { Action } from "svelte/action";
+
+export const validateLength: Action<
+  Node,
+  {
+    min?: number;
+    max?: number;
+    onvalid?: () => void;
+    oninvalid?: () => void;
+    oninput?: (isValid: boolean) => void;
+  }
+> = (
+  node,
+  { min = 0, max = 10, onvalid = () => null, oninvalid = () => null, oninput = () => null } = {},
+) => {
+  let isValid = true;
+  let errorElement: HTMLElement | null = null;
+
+  function validate(): void {
+    if (!["INPUT", "TEXTAREA"].includes(node.nodeName)) {
+      console.error("Can only be used with input or textarea");
+      return;
+    }
+
+    // @ts-expect-error We know it's a correct input element
+    const element: HTMLInputElement = node;
+    const {
+      value: { length },
+    } = element;
+
+    isValid = length >= min && length <= max;
+
+    if (isValid) {
+      onvalid();
+      removeErrorElement();
+    } else {
+      oninvalid();
+      createOrUpdateErrorElement(element, length);
+    }
+
+    element.classList.toggle("form-outline-error", !isValid);
+
+    oninput(isValid);
+  }
+
+  function createOrUpdateErrorElement(element: HTMLInputElement, currentLength: number): void {
+    const label = `Min: ${min} - Max: ${max} - Current: ${currentLength}`;
+
+    if (errorElement) {
+      errorElement.innerText = label;
+      return;
+    }
+
+    errorElement = document.createElement("div");
+    errorElement.classList.add("form-text-error");
+    errorElement.innerText = label;
+
+    element.insertAdjacentElement("afterend", errorElement);
+  }
+
+  function removeErrorElement() {
+    if (!errorElement) return;
+
+    errorElement!.remove();
+    errorElement = null;
+  }
+
+  node.addEventListener("input", validate);
+
+  return {
+    destroy() {
+      node.removeEventListener("input", validate);
+    },
+  };
+};

--- a/src/lib/components/form/BuildForm.svelte
+++ b/src/lib/components/form/BuildForm.svelte
@@ -20,6 +20,7 @@
   import type { z } from "zod";
   import { goto } from "$app/navigation";
   import { buildPath } from "$lib/utils/routes";
+  import { validateLength } from "$src/lib/actions/validateLength";
 
   interface Props {
     availableTalents: AvailableTalents;
@@ -48,6 +49,9 @@
   let heroName: HeroName | null = $state(build.heroName as HeroName);
   let issues: string[] = $state([]);
   let saving = $state(false);
+
+  const validations: Record<string, boolean> = $state({});
+  const containsErrors = $derived(!Object.values(validations).every(Boolean));
 
   const selectedHero = $derived(heroFromHeroName(heroName as HeroName));
 
@@ -244,9 +248,11 @@
     <input
       type="text"
       class="form-input form-input--large"
-      bind:value={build.buildTitle}
+      class:form-input--error={validations.title}
       name="title"
       id="title"
+      bind:value={build.buildTitle}
+      use:validateLength={{ min: 10, max: 70, oninput: (isValid) => (validations.title = isValid) }}
     />
   </div>
 
@@ -258,9 +264,15 @@
     </p>
     <textarea
       class="form-textarea"
-      bind:value={build.description}
+      class:form-textarea--error={validations.description}
       name="description"
       aria-describedby="description"
+      bind:value={build.description}
+      use:validateLength={{
+        min: 20,
+        max: 300,
+        oninput: (isValid) => (validations.description = isValid),
+      }}
     ></textarea>
   </div>
 
@@ -333,9 +345,14 @@
       </p>
       <textarea
         class="form-textarea"
-        bind:value={() => currentRound?.note || "", (v) => (currentRound.note = v)}
         name="round-notes"
         aria-describedby="round-notes"
+        bind:value={() => currentRound?.note || "", (v) => (currentRound.note = v)}
+        use:validateLength={{
+          min: 0,
+          max: 500,
+          oninput: (isValid) => (validations[`note-${currentRound}`] = isValid),
+        }}
       ></textarea>
     </div>
   </div>
@@ -357,13 +374,18 @@
     </p>
     <textarea
       class="form-textarea form-textarea--large"
-      bind:value={build.additionalNotes}
       name="additional-notes"
       aria-describedby="additional-notes"
+      bind:value={build.additionalNotes}
+      use:validateLength={{
+        min: 0,
+        max: 10000,
+        oninput: (isValid) => (validations.additionalNotes = isValid),
+      }}
     ></textarea>
   </div>
 
-  <button class="button button--large save" disabled={saving}>
+  <button class="button button--large save" disabled={saving || containsErrors}>
     {#if saving}
       Saving...
     {:else}

--- a/src/lib/scss/general/_form.scss
+++ b/src/lib/scss/general/_form.scss
@@ -65,3 +65,19 @@
     margin: 0;
   }
 }
+
+.form-outline-error {
+  outline: 2px solid $red;
+
+  &:focus {
+    outline-color: $red;
+  }
+}
+
+.form-text-error {
+  position: absolute;
+  color: $red;
+  padding-top: 0.25rem;
+  font-family: $font-stack-brand;
+  font-size: $font-size-small;
+}

--- a/src/lib/types/build.ts
+++ b/src/lib/types/build.ts
@@ -154,7 +154,7 @@ export const BuildDataSchema = z.object({
     .length(ROUND_MAX, { message: `Must provide ${ROUND_MAX} rounds of information` }),
   additionalNotes: z
     .string()
-    .max(5000, { message: "Description is too long! Maximum 5000" })
+    .max(10000, { message: "Description is too long! Maximum 10000" })
     .nullable(),
 });
 


### PR DESCRIPTION
## Description

In order to let the user know they did something wrong _before_ submitting, we now show inline errors right in the form. This is done through a Svelte action to keep everything fairly self contained and easy to re-use.

## Screenshots

![image](https://github.com/user-attachments/assets/68b6d1c7-6123-454f-bd00-74567ae86a18)
![image](https://github.com/user-attachments/assets/a4b6c0b4-3d0c-4d59-8e00-5559e3731194)
