### PR TITLE
fix: Only show load more button on homepage when relevant

### DIFF
--- a/src/routes/(main)/+page.svelte
+++ b/src/routes/(main)/+page.svelte
@@ -8,6 +8,7 @@
   import type { FullStadiumBuild as Build } from "$lib/types/build";
   import { api } from "$lib/utils/api";
   import type { PageableBuildsSnapshot } from "$src/lib/types/snapshot";
+  import { BUILDS_PAGE_SIZE } from "$src/lib/types/page";
 
   const { data } = $props();
 
@@ -58,7 +59,7 @@
 
 <BuildsList header="Latest Builds" builds={latestBuilds} />
 
-{#if latestBuilds}
+{#if latestBuilds?.length % BUILDS_PAGE_SIZE === 0}
   <center>
     <a
       href="/latest?page={currentPage + 1}"


### PR DESCRIPTION
Same strategy as on other pages