### PR TITLE
chore: allow links in form of `/[build-id]`

### DIFF
--- a/src/routes/(main)/[buildId]/+server.ts
+++ b/src/routes/(main)/[buildId]/+server.ts
@@ -1,0 +1,12 @@
+import { prisma } from "$src/database/prismaClient.server";
+import { buildPath } from "$src/lib/utils/routes";
+import { error, redirect, type RequestHandler } from "@sveltejs/kit";
+
+export const GET: RequestHandler = async ({ params }) => {
+  const { buildId } = params;
+
+  const build = await prisma.stadiumBuild.findFirst({ where: { id: buildId } });
+  if (!build) error(404, "Build not found");
+
+  redirect(308, buildPath(build));
+};


### PR DESCRIPTION
This PR adds a small redirect from that page to the full build page. The idea is to allow the user to copy a shortlink which is easily shareable. While this PR doesn't add that to the build page yet, it does set up the backend for that feature!
