### PR TITLE
style: Add divider between tags and author

### DIFF
--- a/src/routes/(main)/build/[id]-[slug]/+page.svelte
+++ b/src/routes/(main)/build/[id]-[slug]/+page.svelte
@@ -197,8 +197,16 @@
   }
 
   .divider {
+    display: block;
+    min-height: 0.25rem;
     opacity: 0.5;
     color: $color-text-alt;
+    font-size: 0;
+
+    @include breakpoint(tablet) {
+      display: inline;
+      font-size: inherit;
+    }
   }
 
   .datetime {

--- a/src/routes/(main)/build/[id]-[slug]/+page.svelte
+++ b/src/routes/(main)/build/[id]-[slug]/+page.svelte
@@ -81,9 +81,11 @@
       <h1 class="title">{title}</h1>
 
       <a class="hero" href="/hero/{hero.name}">{hero.name}</a>
-      <a class="author" href="/user/{encodeURIComponent(author.name!)}" itemprop="author"
-        >{cleanName(author.name!)}</a
-      >
+      <a class="author" href="/user/{encodeURIComponent(author.name!)}" itemprop="author">
+        {cleanName(author.name!)}
+      </a>
+
+      <span class="divider">•</span>
 
       <Tags {tags} />
 


### PR DESCRIPTION
## Description

Tiny thing, but this was supposed to be there but got lost between merges. Additionally, I've adjusted the divider to break sections on mobile.

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/0bf1d239-544b-4cca-8e1e-a91ca72593cb) | ![image](https://github.com/user-attachments/assets/0b00af3b-0b1f-4764-a2e9-605f84175193)

On mobile it shows each segment on a separate line.
![image](https://github.com/user-attachments/assets/39e6d372-6088-47fa-8811-8956e62afc61)


