### PR TITLE
fix: Don't show tags divider when no tags are given

### DIFF
--- a/src/routes/(main)/build/[id]/[slug]/+page.svelte
+++ b/src/routes/(main)/build/[id]/[slug]/+page.svelte
@@ -89,9 +89,10 @@
         {cleanName(author.name!)}
       </a>
 
-      <span class="divider">•</span>
-
-      <Tags {tags} />
+      {#if tags.length}
+        <span class="divider">•</span>
+        <Tags {tags} />
+      {/if}
 
       <span class="divider">•</span>
 


### PR DESCRIPTION
Closes #119 

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/fdf23fbc-11ad-45f6-a63c-9c584a7b17e7) | ![image](https://github.com/user-attachments/assets/2ea52ae0-ede5-40ac-86d8-d38ae38dfd0e)
![image](https://github.com/user-attachments/assets/3b2b0938-3606-4fbc-bc45-05215a2e4706) | ![image](https://github.com/user-attachments/assets/9e5195ed-dc0b-46fa-a1ee-aa2afcbc54c7)
