### PR TITLE
chore: Increase note length to 1500

### DIFF
--- a/src/lib/components/form/BuildForm.svelte
+++ b/src/lib/components/form/BuildForm.svelte
@@ -375,7 +375,7 @@
         bind:value={() => currentRound?.note || "", (v) => (currentRound.note = v)}
         lengthValidation={{
           min: 0,
-          max: 500,
+          max: 1500,
           oninput: (isValid) => (validations[`note-${currentRound}`] = isValid),
         }}
       >


### PR DESCRIPTION
It already was 1500 in the backend, the frontend limited it to 500.

Closes #120