### PR TITLE
chore: Use lazy loading for many images

### DIFF
--- a/src/lib/components/content/Healthbar.svelte
+++ b/src/lib/components/content/Healthbar.svelte
@@ -47,7 +47,7 @@
   <div class="bar" aria-label="{label}: {totalPoints}">
     <div class="icon">
       <Popover>
-        <img src={icon} alt={label} height="24" width="24" />
+        <img src={icon} alt={label} height="24" width="24" loading="lazy" />
 
         {#snippet content()}
           <div class="detail">

--- a/src/lib/components/content/Item.svelte
+++ b/src/lib/components/content/Item.svelte
@@ -24,7 +24,7 @@
     {#snippet header()}
       <div class="item {rarity.toLowerCase()}" class:sold>
         <div class="icon">
-          <img src={iconURL} alt={name} />
+          <img src={iconURL} alt={name} loading="lazy" />
         </div>
       </div>
 
@@ -41,7 +41,7 @@
   <Popover onclick={() => onclick(item)}>
     <div class="item {rarity.toLowerCase()}" class:large class:sold>
       <div class="icon">
-        <img src={iconURL} alt={name} height={imageSize} />
+        <img src={iconURL} alt={name} height={imageSize} loading="lazy" />
       </div>
 
       {#if sold}

--- a/src/lib/components/content/ItemStastisticsBar.svelte
+++ b/src/lib/components/content/ItemStastisticsBar.svelte
@@ -34,7 +34,7 @@
   <div class="bar" aria-label="{label}: {value}{suffix}">
     <div class="icon">
       <Popover>
-        <img src={icon} alt={label} height="24" width="24" />
+        <img src={icon} alt={label} height="24" width="24" loading="lazy" />
 
         {#snippet content()}
           <div class="detail">

--- a/src/lib/components/content/Power.svelte
+++ b/src/lib/components/content/Power.svelte
@@ -29,7 +29,7 @@
   <Card {outline} onclick={() => onclick(power)}>
     {#snippet header()}
       <div class="power">
-        <img src={iconURL} alt={name} />
+        <img src={iconURL} alt={name} loading="lazy" />
       </div>
 
       {name}
@@ -40,7 +40,7 @@
 {:else}
   <Popover onclick={() => onclick(power)}>
     <div class="power" class:large>
-      <img src={iconURL} alt={name} width={imageSize} height={imageSize} />
+      <img src={iconURL} alt={name} width={imageSize} height={imageSize} loading="lazy" />
     </div>
 
     {#snippet content()}

--- a/src/lib/components/content/TalentRichInsert.svelte
+++ b/src/lib/components/content/TalentRichInsert.svelte
@@ -18,7 +18,7 @@
 
 <Popover inline {onshow} transition={false}>
   <span class="talent">
-    <img src="/images/talents/{talentName}.png" alt="" height="16" width="16" />
+    <img src="/images/talents/{talentName}.png" alt="" height="16" width="16" loading="lazy" />
     {talentName}
   </span>
 


### PR DESCRIPTION
## Description

We're loading quite a few images, many of which might be offscreen. Not necessarily, so we might cause some images to load slightly later than might be ideal, but non of these images are crucial to the layout to the point where the extra millisecond makes the difference.