### PR TITLE
feat: Allow talent previews in round info notes

### DIFF
--- a/src/lib/components/content/RoundInfo.svelte
+++ b/src/lib/components/content/RoundInfo.svelte
@@ -66,5 +66,6 @@
 
   .note {
     margin: var(--gap) 0 0;
+    white-space: pre-wrap;
   }
 </style>

--- a/src/lib/components/content/RoundInfo.svelte
+++ b/src/lib/components/content/RoundInfo.svelte
@@ -2,6 +2,7 @@
   import type { FullRoundInfo } from "$lib/types/round";
   import Item from "./Item.svelte";
   import Power from "./Power.svelte";
+  import TalentRichPreviews from "./TalentRichPreviews.svelte";
 
   interface Props {
     roundInfo: FullRoundInfo;
@@ -37,7 +38,7 @@
 
   {#if note}
     <p class="note">
-      {note}
+      <TalentRichPreviews text={note} />
     </p>
   {/if}
 </div>


### PR DESCRIPTION
## Description

I'm a bit hesitant to allow full markdown in round info notes. Having full on titles is a bit much there, having bold and italic would be nice, but anything more than that might be a bit much. Talent previews seems like a good idea, though!

## Screenshots
![image](https://github.com/user-attachments/assets/b23ef76f-03d0-4fc1-9377-9c1dd5677db9)
