### PR TITLE
fix: Insert double line breaks where relevant in markdown content

### DIFF
--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -2,7 +2,7 @@ import snarkdown from "snarkdown";
 import DOMPurify from "isomorphic-dompurify";
 
 export function markdown(text: string): string {
-  let parsed = snarkdown(text);
+  let parsed = useParagraphs(text);
   parsed = updateLinkTargets(parsed);
   parsed = updateHeadingAriaLevels(parsed);
 
@@ -22,4 +22,17 @@ function updateLinkTargets(text: string): string {
 // Insert aria-level tags for h1 and h2 titles, retaining their styling, but making sure we control their importance.
 function updateHeadingAriaLevels(text: string): string {
   return text.replace(/<h1>/g, '<h1 aria-level="3">').replace(/<h2>/g, '<h2 aria-level="3">');
+}
+
+// Replace double new lines with paragraphs. Snarkdown normally parses any amount of newlines with breaks, never creating a paragraph.
+// https://github.com/developit/snarkdown/issues/11
+function useParagraphs(text: string): string {
+  return text
+    .split(/(?:\r?\n){2,}/)
+    .map((line: string) =>
+      [" ", "\t", "#", "- ", "* ", "> "].some((char) => line.startsWith(char))
+        ? snarkdown(line)
+        : `<p>${snarkdown(line)}</p>`,
+    )
+    .join("\n");
 }

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -2,7 +2,7 @@ import snarkdown from "snarkdown";
 import DOMPurify from "isomorphic-dompurify";
 
 export function markdown(text: string): string {
-  let parsed = useDoubleBreaks(text);
+  let parsed = snarkdownWithDoubleLinebreaks(text);
   parsed = updateLinkTargets(parsed);
   parsed = updateHeadingAriaLevels(parsed);
 
@@ -28,7 +28,7 @@ function updateHeadingAriaLevels(text: string): string {
 // Ideally we'd use paragraphs, but the way we parse talent previews get in the way of that. The next best
 // thing is double breaks, which is close enough.
 // https://github.com/developit/snarkdown/issues/11
-function useDoubleBreaks(text: string): string {
+function snarkdownWithDoubleLinebreaks(text: string): string {
   const lines = text.split(/(?:\r?\n){2,}/);
   const markdownCharacters = [" ", "\t", "#", "- ", "* ", "> "];
 


### PR DESCRIPTION
## Description

Snarkdown doesn't support paragraphs. Any amount of newlines are always replaced with single breaks. Paragraphs are cool and we want them, but we actually can't easily do that. We can't use paragraph directly because of how we parse talent previews. Instead, here we use double linebreaks, which visually gives the same appearance.

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/b8d7914c-9797-46a3-a78e-ef486f516b07) | ![image](https://github.com/user-attachments/assets/eb0c5f3c-00e3-4f4a-9480-bb15beae52dd)
