### PR TITLE
feat: Add hero select to hero pages

### DIFF
--- a/src/routes/(main)/hero/[heroName]/+page.svelte
+++ b/src/routes/(main)/hero/[heroName]/+page.svelte
@@ -8,13 +8,14 @@
   import { api } from "$lib/utils/api";
   import type { PageableBuildsSnapshot } from "$src/lib/types/snapshot";
   import { BUILDS_PAGE_SIZE } from "$lib/constants/page";
+  import Heroes from "$src/lib/components/content/Heroes.svelte";
 
   const { data } = $props();
 
   const { heroName } = $derived(data);
   const currentRound: CurrentRound = $state({ value: ROUND_MAX });
 
-  let builds: Build[] = $state(data?.builds ?? []);
+  let builds: Build[] = $derived(data?.builds ?? []);
   let loading = $state(false);
   let currentPage = $state(1);
 
@@ -54,6 +55,8 @@
 <svelte:head>
   <title>{heroName} | OW Armory</title>
 </svelte:head>
+
+<Heroes />
 
 <BuildsList header="Builds for {heroName}" {builds} />
 


### PR DESCRIPTION
## Description

Helps with navigating between heroes. I also have to change `builds` to a derived rune so that the list updates as expected when `data` changes.

## Screenshots

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/8005e8b8-622c-4d1a-aa3f-63e7f4ef42b3) | ![image](https://github.com/user-attachments/assets/3873e451-b7e8-4222-abc0-e0e9da98f5f3)
