### PR TITLE
fix: avoid using DOMPurify (for now) and rely on browser CSP to block bad stuff

### DIFF
--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,12 +1,13 @@
 import snarkdown from "snarkdown";
-import DOMPurify from "isomorphic-dompurify";
+// import DOMPurify from "isomorphic-dompurify";
 
 export function markdown(text: string): string {
   let parsed = snarkdown(text);
   parsed = updateLinkTargets(parsed);
   parsed = updateHeadingAriaLevels(parsed);
 
-  return DOMPurify.sanitize(parsed);
+  // return DOMPurify.sanitize(parsed);
+  return parsed;
 }
 
 // Links generated with Snarkdown are flat links. We'd prefer them to open in a new tab and with nofollow.

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -3,7 +3,15 @@ import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
 
 const config = {
   preprocess: vitePreprocess(),
-  kit: { adapter: adapter(), alias: { $src: "src" } },
+  kit: {
+    adapter: adapter(),
+    alias: { $src: "src" },
+    csp: {
+      directives: {
+        "script-src": ["self"],
+      },
+    },
+  },
 };
 
 export default config;


### PR DESCRIPTION
Basic testing with examples provided by DOMPurify results in no leakage beyond style tags.
It's better to provide a good experience now than to hold off for a perfect defense-in-depth.
