### PR TITLE
fix: retain hero-specific items when loading build edit form

### DIFF
--- a/src/lib/components/form/BuildForm.svelte
+++ b/src/lib/components/form/BuildForm.svelte
@@ -51,7 +51,7 @@
 
   let currentRoundIndex = $state(0);
   let currentTalentTypeTab = $state(itemTalentTypes[0]);
-  let heroName: HeroName | null = $state(build.heroName as HeroName);
+  const heroName: HeroName | null = $derived(build.heroName as HeroName);
   let issues: string[] = $state([]);
   let saving = $state(false);
   let query = $state("");
@@ -109,7 +109,7 @@
     event.preventDefault();
 
     build.heroName = hero.name;
-    heroName = hero.name;
+    build = { ...build };
   }
 
   function selectItem(item: Item): void {
@@ -189,9 +189,13 @@
   function removeHeroSpecificTalents(): void {
     build.roundInfos.forEach((roundInfo) => {
       roundInfo.sections.forEach((section) => {
-        if (section.power?.heroName !== heroName) section.power = null;
-        section.purchasedItems = section.purchasedItems.filter((item) => heroName != item.heroName);
-        section.soldItems = section.soldItems.filter((item) => heroName != item.heroName);
+        if (section.power?.heroName != heroName) section.power = null;
+        section.purchasedItems = section.purchasedItems.filter(
+          (item) => item.heroName == null || heroName == item.heroName,
+        );
+        section.soldItems = section.soldItems.filter(
+          (item) => item.heroName == null || heroName == item.heroName,
+        );
       });
     });
 

--- a/src/lib/utils/routes.ts
+++ b/src/lib/utils/routes.ts
@@ -9,6 +9,6 @@ export function buildShortPath(build: Pick<FullStadiumBuild, "id">): string {
   return `/${build.id}`;
 }
 
-export function buildEditPath(build: FullStadiumBuild): string {
+export function buildEditPath(build: Pick<FullStadiumBuild, "id" | "buildTitle">): string {
   return buildPath(build) + "/edit";
 }


### PR DESCRIPTION
This PR fixes a bug where hero-specific items were removed when loading the build edit page.
