### PR TITLE
fix: Wrap build name when necessary

### DIFF
--- a/src/lib/components/content/Build.svelte
+++ b/src/lib/components/content/Build.svelte
@@ -86,6 +86,8 @@
     cursor: pointer;
 
     @include breakpoint(tablet) {
+      display: grid;
+      grid-template-columns: 50px 1fr 1fr;
       flex-wrap: nowrap;
     }
 
@@ -108,16 +110,14 @@
   .name {
     display: block;
     margin-bottom: 0.25rem;
-    overflow: hidden;
-    text-overflow: ellipsis;
     font-family: $font-stack-brand;
     font-weight: bold;
     color: $white;
     text-decoration: none;
-    white-space: nowrap;
 
     &:hover {
-      box-shadow: 0 2px 0 $white;
+      text-decoration: underline;
+      text-decoration-thickness: 2px;
     }
   }
 


### PR DESCRIPTION
## Description

When a build has a very long name, it pushes the items into a very tight space. This fixes that by instead allowing build titles to wrap, leaving an equal space for the title and items when necessary.

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/2a33e72b-9dd6-489d-829d-7240ec573864) | ![image](https://github.com/user-attachments/assets/6be2594c-7600-4508-baa1-0b484fe4a8d1)
