### PR TITLE
fix: Don't include full statmods in stats

### DIFF
--- a/src/lib/types/build.ts
+++ b/src/lib/types/build.ts
@@ -17,19 +17,25 @@ export const ItemCategory = {
 } as const;
 export type ItemCategory = (typeof ItemCategory)[keyof typeof ItemCategory];
 
-export const FullStatModInclude = { stat: true };
+export const CleanStatInclude = {
+  id: true,
+  name: true,
+  description: true,
+  iconURL: true,
+  statType: true,
+} as const;
+
+export const FullStatModInclude = {
+  stat: {
+    select: CleanStatInclude,
+  },
+} as const satisfies Prisma.StatModInclude;
+
 export const FullItemInclude = {
   statMods: {
     include: {
       stat: {
-        include: {
-          statMods: {
-            include: FullStatModInclude,
-            orderBy: {
-              orderIndex: "asc",
-            },
-          },
-        },
+        select: CleanStatInclude,
       },
     },
     orderBy: {


### PR DESCRIPTION
For a reason that I'm not 100% sure on, the `stat` field in `statMods` included `statMods` itself, which then seemed to include all `statMods` relations ever created for that stat? This resulted in builds having giant arrays of irrelevant statmods on each stat that only grows as more builds are created. JSON returns for builds could easily be be up to 1MB already, and overview pages could be 5MB+ already.

Anyway, this fixes that by no longer including `statMods` within `stat`, only returning the relevant fields instead.

Before:
![image](https://github.com/user-attachments/assets/2ff1e969-a522-4447-92de-92e1aa329681)
After:
![image](https://github.com/user-attachments/assets/b61759d8-0e80-43b6-9e52-6605d3630a4c)
