### PR TITLE
chore(seo): Adjust title for hero pages

### DIFF
--- a/src/routes/(main)/hero/[heroName]/+page.svelte
+++ b/src/routes/(main)/hero/[heroName]/+page.svelte
@@ -58,7 +58,7 @@
 
 <Heroes />
 
-<BuildsList header="Builds for {heroName}" {builds} />
+<BuildsList header="Stadium builds for {heroName}" {builds} />
 
 {#if builds.length % BUILDS_PAGE_SIZE === 0}
   <center>


### PR DESCRIPTION
People might be likely to google for "Reinhardt stadium builds" or something along those lines. by including all those words in the h1, we might rank better for those searches.