### PR TITLE
style: Slightly reduce hero size

### DIFF
--- a/src/lib/components/content/Hero.svelte
+++ b/src/lib/components/content/Hero.svelte
@@ -30,7 +30,7 @@
 
 <style lang="scss">
   .hero {
-    --size: #{px-to-rem(50)};
+    --size: #{px-to-rem(48)};
     display: block;
     flex: 0 0 var(--size);
     width: var(--size);


### PR DESCRIPTION
## Description

With 1 hero added the hero grid layout turns quite ugly. Reducing it ever so slightly takes care of that on desktop layouts. Once more heroes are added we can up this back to 50 again.

## Screenshots
### Before
![image](https://github.com/user-attachments/assets/03861f85-c5a3-4d45-8a60-d6dfee255b6e)
### After
![image](https://github.com/user-attachments/assets/42550179-545c-4902-9bea-1797d2730b45)


