### PR TITLE
style: Allow scrolling in tabs

### DIFF
--- a/src/lib/components/form/BuildForm.svelte
+++ b/src/lib/components/form/BuildForm.svelte
@@ -467,6 +467,7 @@
     padding: 0.5rem 1rem;
     background: $color-border;
     border-radius: $border-radius $border-radius 0 0;
+    overflow: auto;
 
     &.dark {
       background: $color-bg-dark;
@@ -480,6 +481,7 @@
     color: $color-text-alt;
     font-family: $font-stack-brand;
     font-size: $font-size-base;
+    white-space: nowrap;
 
     &:hover {
       color: $white;


### PR DESCRIPTION
## Description

On mobile tabs were hardly useable because you could not see all tabs. This takes care of that by allowing you to scroll.

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/717aaf85-d364-4ffd-979a-712c5a87391d) | ![image](https://github.com/user-attachments/assets/42326a1e-f64f-4331-bace-0805448b487b)
