### PR TITLE
feat: show time since build update in list

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
   "lint-staged": {
     "*.svelte*": "eslint --fix",
     "*.{ts,js,svelte,svelte.ts,svelte.js,scss}": "prettier --write"
+  },
+  "dependencies": {
+    "date-fns": "^4.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
     devDependencies:
       '@auth/core':
         specifier: ^0.39.0
@@ -990,6 +994,9 @@ packages:
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -2970,6 +2977,8 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
+
+  date-fns@4.1.0: {}
 
   debug@4.4.0:
     dependencies:

--- a/src/lib/components/content/Build.svelte
+++ b/src/lib/components/content/Build.svelte
@@ -12,6 +12,8 @@
   import Item from "./Item.svelte";
   import Power from "./Power.svelte";
   import { cleanName } from "$src/lib/utils/user";
+  import { formatDistanceToNowStrict } from "date-fns";
+  import { toSimpleDate } from "$src/lib/utils/datetime";
 
   const { build }: { build: FullStadiumBuild } = $props();
 
@@ -52,6 +54,15 @@
       <a href={`/user/${encodeURIComponent(build.author.name!)}`}>
         {cleanName(build.author.name!)}
       </a>
+      <span class="divider">•</span>
+      <time
+        class="datetime"
+        title={toSimpleDate(build.updatedAt.toString())}
+        itemprop="dateModified"
+        datetime={build.updatedAt.toString()}
+      >
+        Last updated {formatDistanceToNowStrict(build.updatedAt)} ago
+      </time>
     </div>
   </div>
 
@@ -149,5 +160,24 @@
     @include breakpoint(tablet) {
       justify-content: flex-end;
     }
+  }
+
+  .divider {
+    display: block;
+    min-height: 0.25rem;
+    opacity: 0.5;
+    color: $color-text-alt;
+    font-size: 0;
+
+    @include breakpoint(tablet) {
+      display: inline;
+      font-size: inherit;
+    }
+  }
+
+  .datetime {
+    color: $color-text-alt;
+    font-size: $font-size-small;
+    font-style: italic;
   }
 </style>

--- a/src/routes/(main)/build/[id]/[slug]/+page.svelte
+++ b/src/routes/(main)/build/[id]/[slug]/+page.svelte
@@ -27,6 +27,7 @@
   import ShareInput from "$src/lib/components/form/ShareInput.svelte";
   import { Tween } from "svelte/motion";
   import { quintOut } from "svelte/easing";
+  import { formatDistanceToNowStrict } from "date-fns";
 
   const { data } = $props();
 
@@ -106,8 +107,13 @@
 
       <span class="divider">•</span>
 
-      <time class="datetime" itemprop="dateModified" datetime={updatedAt.toString()}>
-        Last updated on {toSimpleDate(updatedAt.toString())}
+      <time
+        class="datetime"
+        title={toSimpleDate(updatedAt.toString())}
+        itemprop="dateModified"
+        datetime={updatedAt.toString()}
+      >
+        Last updated {formatDistanceToNowStrict(updatedAt)} ago
       </time>
     </div>
   </header>


### PR DESCRIPTION
This PR adds text which informs the user about when a given build was last updated in the build list, along with changing "Last updated" text to use relative units instead of absolute dates. Absolute dates are still visible on hover.

**Motivation**:
As Stadium is frequently balanced, builds which may have been top-tier in previous patches may become less powerful (intentionally so!) as the team balances the game. Adding information about when a build was last updated enables players to make more informed decisions about which builds to examine further.

### Example list
![image](https://github.com/user-attachments/assets/6b3eec95-c3ec-4b81-b6f9-9c11390a3ec5)

### Updated build view page header
![image](https://github.com/user-attachments/assets/efbd9b43-d344-4464-8547-23a33b55b2b6)

