### PR TITLE
feat: enable ascii characters to search for unicode lookalikes

### DIFF
--- a/src/lib/components/form/BuildForm.svelte
+++ b/src/lib/components/form/BuildForm.svelte
@@ -32,6 +32,7 @@
   import CurrencyIcon from "../icon/CurrencyIcon.svelte";
   import { Tween } from "svelte/motion";
   import { quintOut } from "svelte/easing";
+  import { transliterate } from "$src/lib/utils/string";
 
   interface Props {
     availableTalents: AvailableTalents;
@@ -276,7 +277,7 @@
   function filterTalents(talent: Item[] | Power[]): boolean {
     // Filter on the full object by stringifying it. Bit ugly, but that makes it easy to filter by name,
     // description, and stat names all at once.
-    return JSON.stringify(talent).toLowerCase().includes(query.toLowerCase());
+    return transliterate(JSON.stringify(talent).toLowerCase()).includes(query.toLowerCase());
   }
 </script>
 

--- a/src/lib/utils/string.spec.ts
+++ b/src/lib/utils/string.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { camelCaseToTitleCase } from "./string";
+import { camelCaseToTitleCase, transliterate } from "./string";
 
 describe("camelCaseToTitleCase", () => {
   it("converts one-word names", () => {
@@ -16,5 +16,24 @@ describe("camelCaseToTitleCase", () => {
 
   it("Does not separate letters of an abbreviation", () => {
     expect(camelCaseToTitleCase("iconURL")).toBe("Icon URL");
+  });
+});
+
+describe("transliterate", () => {
+  it("handles a normal ascii string", () => {
+    expect(transliterate("The quick brown fox jumped over the lazy dog. 12345")).toBe(
+      "The quick brown fox jumped over the lazy dog. 12345",
+    );
+    expect(transliterate("#1 Single")).toBe("#1 Single");
+    expect(transliterate("I.V. Drip")).toBe("I.V. Drip");
+    expect(transliterate("Build-A-Blast Buckshot")).toBe("Build-A-Blast Buckshot");
+    expect(transliterate("Nano Cola™ Nitrous")).toBe("Nano ColaTM Nitrous");
+  });
+
+  it("helps when searching for lookalike-ish characters", () => {
+    expect(transliterate("Rüstung von Wilhelm")).toBe("Rustung von Wilhelm");
+    expect(transliterate("Lille Fælde")).toBe("Lille Faelde");
+    expect(transliterate("Volley à Deux")).toBe("Volley a Deux");
+    expect(transliterate("Lúcio")).toBe("Lucio");
   });
 });

--- a/src/lib/utils/string.ts
+++ b/src/lib/utils/string.ts
@@ -3,3 +3,8 @@ export function camelCaseToTitleCase(camelCaseString: string): string {
     .replace(/((?<![A-Z])[A-Z])/g, " $1")
     .replace(/^./, (str) => str.toUpperCase());
 }
+
+const combiningUnicodeChars = /[\u0300-\u036F]/g;
+export function transliterate(input: string): string {
+  return input.normalize("NFKD").replace(combiningUnicodeChars, "").replace("\u00E6", "ae");
+}

--- a/src/routes/(main)/(talents)/+layout.svelte
+++ b/src/routes/(main)/(talents)/+layout.svelte
@@ -5,6 +5,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import TalentsNavigation from "$lib/components/content/TalentsNavigation.svelte";
+  import { transliterate } from "$src/lib/utils/string";
   import { setContext } from "svelte";
 
   const { children } = $props();
@@ -37,7 +38,7 @@
   function matchQuery(talentString: string): boolean {
     const queryWords = query.toLowerCase().split(/\s+/).filter(Boolean);
 
-    return queryWords.every((word) => talentString.toLowerCase().includes(word));
+    return queryWords.every((word) => transliterate(talentString.toLowerCase()).includes(word));
   }
 
   setContext("talentFilter", setTalentFilter);

--- a/src/routes/admin/talents/+layout.svelte
+++ b/src/routes/admin/talents/+layout.svelte
@@ -4,6 +4,7 @@
 
 <script lang="ts">
   import TalentsNavigation from "$lib/components/content/TalentsNavigation.svelte";
+  import { transliterate } from "$src/lib/utils/string";
   import { setContext } from "svelte";
 
   const { children } = $props();
@@ -36,7 +37,7 @@
   function matchQuery(talentString: string): boolean {
     const queryWords = query.toLowerCase().split(/\s+/).filter(Boolean);
 
-    return queryWords.every((word) => talentString.toLowerCase().includes(word));
+    return queryWords.every((word) => transliterate(talentString.toLowerCase()).includes(word));
   }
 
   setContext("talentFilter", setTalentFilter);


### PR DESCRIPTION
This PR adds the ability to search for items and powers with lookalike ASCII characters. For example, searching for "Rüstung von Wilhelm" previously did not appear with the search term "Rustung", but now it does.

[Screencast_20250622_235241.webm](https://github.com/user-attachments/assets/dd397ad9-623d-4c91-ae81-87a437ae01d6)

