### PR TITLE
perf: speed up GitHub Actions installation of Playwright with dependency cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Run Tests
 
 env:
   AUTH_TRUST_HOST: 1
+  AUTH_SECRET: "pOx1PSOhxNeZE4xkUbh5DCoZZPvNVamiZ/dqxxGvOzo="
   AUTH_BATTLENET_CLIENT_ID: "NOT_AVAILABLE"
   AUTH_BATTLENET_CLIENT_SECRET: "NOT_AVAILABLE"
   DATABASE_URL: "postgresql://postgres:Password123@localhost:5432/postgres?schema=public"


### PR DESCRIPTION
Installing Playwright with its dependencies increased CI runtime from <30s to 3+ mins. This PR aims to mitigate that by adding a cache for the Playwright binaries.